### PR TITLE
Filter out group destinations from data processing scripts

### DIFF
--- a/destinations.json
+++ b/destinations.json
@@ -1,817 +1,304 @@
 [
   {
-    "name": "Bonaire",
-    "slug": "bonaire",
-    "region": "Caribbean",
-    "center": [
-      12.1836,
-      -68.3177
-    ],
-    "bounds": [
-      [
-        12.02,
-        -68.42
-      ],
-      [
-        12.31,
-        -68.22
-      ]
-    ],
-    "description": "A Caribbean island known for its pristine coral reefs and excellent shore diving opportunities.",
-    "overviewFile": "overview.md",
-    "countryCode": "BQ"
+    "name": "India",
+    "slug": "india",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "Remote island diving in the Andaman Sea with pristine coral ecosystems.",
+    "countryCode": "IN"
   },
   {
-    "name": "Curacao",
-    "slug": "curacao",
-    "region": "Caribbean",
-    "center": [
-      12.221,
-      -69.0103
-    ],
-    "bounds": [
-      [
-        12.0679,
-        -69.1586
-      ],
-      [
-        12.374,
-        -68.8619
-      ]
-    ],
-    "description": "Dutch Caribbean paradise offering world-class shore diving with colorful coral reefs, historic wrecks, and diverse marine life including sea turtles and tropical fish. Known for crystal-clear waters and excellent visibility.",
-    "overviewFile": "overview.md",
-    "countryCode": "CW"
+    "name": "Indonesia",
+    "slug": "indonesia",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "The heart of the Coral Triangle with unmatched marine biodiversity across thousands of islands.",
+    "countryCode": "ID"
   },
   {
-    "name": "Bahamas",
-    "slug": "bahamas",
-    "region": "Caribbean",
-    "center": [
-      24.25,
-      -76.0
-    ],
-    "bounds": [
-      [
-        22.0,
-        -80.0
-      ],
-      [
-        27.0,
-        -72.0
-      ]
-    ],
-    "description": "Crystal clear waters with blue holes, sharks, and pristine coral reefs including Tiger Beach.",
-    "overviewFile": "overview.md",
-    "countryCode": "BS"
+    "name": "Japan",
+    "slug": "japan",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "Subtropical reefs, hammerhead schooling sites, and unique temperate marine life.",
+    "countryCode": "JP"
   },
   {
-    "name": "Belize Barrier Reef",
-    "slug": "belize-barrier-reef",
-    "region": "Caribbean",
-    "center": [
-      16.7,
-      -88.0
-    ],
-    "bounds": [
-      [
-        15.5,
-        -89.0
-      ],
-      [
-        18.5,
-        -87.0
-      ]
-    ],
-    "description": "Home to the famous Blue Hole and spectacular reef walls with abundant marine life.",
-    "overviewFile": "overview.md",
-    "countryCode": "BZ"
+    "name": "Malaysia",
+    "slug": "malaysia",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "World-renowned sites in Sabah and pristine reefs off the peninsula.",
+    "countryCode": "MY"
   },
   {
-    "name": "Cayman Islands",
-    "slug": "cayman-islands",
-    "region": "Caribbean",
-    "center": [
-      19.35,
-      -81.25
-    ],
-    "bounds": [
-      [
-        19.0,
-        -82.0
-      ],
-      [
-        19.8,
-        -79.7
-      ]
-    ],
-    "description": "World-class wall dives, excellent visibility, and the famous Stingray City.",
-    "overviewFile": "overview.md",
-    "countryCode": "KY"
+    "name": "Philippines",
+    "slug": "philippines",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "Diverse diving from macro havens to pelagic encounters across 7,000+ islands.",
+    "countryCode": "PH"
   },
   {
-    "name": "Turks and Caicos",
-    "slug": "turks-and-caicos",
-    "region": "Caribbean",
-    "center": [
-      21.8,
-      -72.0
-    ],
-    "bounds": [
-      [
-        21.0,
-        -73.0
-      ],
-      [
-        22.5,
-        -71.0
-      ]
-    ],
-    "description": "Pristine wall dives, reef sharks, and crystal-clear warm Caribbean waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "TC"
+    "name": "Thailand",
+    "slug": "thailand",
+    "region": "Asia",
+    "isGroup": true,
+    "description": "Tropical diving with whale sharks, vibrant reefs, and world-class liveaboard routes.",
+    "countryCode": "TH"
   },
   {
-    "name": "Saba",
-    "slug": "saba",
-    "region": "Caribbean",
+    "name": "Alor Archipelago",
+    "slug": "alor-archipelago",
+    "region": "Asia",
     "center": [
-      17.63,
-      -63.23
+      -8.3,
+      124.35
     ],
     "bounds": [
       [
-        17.6,
-        -63.3
+        -8.52,
+        123.8
       ],
       [
-        17.7,
-        -63.2
+        -8.0,
+        125.2
       ]
     ],
-    "description": "Dramatic pinnacle dives around an extinct volcanic island with pristine reefs.",
+    "description": "Indonesia's rising macro diving destination rivaling Lembeh Strait, with Rhinopias, rare critters, strong currents, and far fewer crowds.",
     "overviewFile": "overview.md",
-    "countryCode": "BQ"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Utila",
-    "slug": "utila",
-    "region": "Caribbean",
+    "name": "Ambon",
+    "slug": "ambon",
+    "region": "Asia",
     "center": [
-      16.1,
-      -86.9
+      -3.7,
+      128.2
     ],
     "bounds": [
       [
-        16.0,
-        -87.0
+        -3.8,
+        128.0
       ],
       [
-        16.2,
-        -86.8
+        -3.5,
+        128.4
       ]
     ],
-    "description": "Famous for whale shark encounters and affordable diving in Honduras.",
+    "description": "Northern Banda Sea muck diving paradise, home to the psychedelic frogfish found nowhere else on Earth, with world-class macro photography opportunities.",
     "overviewFile": "overview.md",
-    "countryCode": "HN"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "British Virgin Islands",
-    "slug": "british-virgin-islands",
-    "region": "Caribbean",
+    "name": "Andaman Islands",
+    "slug": "andaman-islands",
+    "region": "Asia",
     "center": [
-      18.5,
-      -64.5
+      12.0,
+      92.8
     ],
     "bounds": [
       [
-        18.0,
-        -65.0
+        10.5,
+        92.2
       ],
       [
-        19.0,
-        -64.0
+        13.7,
+        93.1
       ]
     ],
-    "description": "Home to the famous RMS Rhone wreck and excellent reef diving.",
+    "description": "Untouched coral reefs and pristine pelagic encounters in remote Indian waters.",
     "overviewFile": "overview.md",
-    "countryCode": "VG"
+    "countryCode": "IN",
+    "parentSlug": "india"
   },
   {
-    "name": "Cozumel",
-    "slug": "cozumel",
-    "region": "Caribbean",
+    "name": "Bali",
+    "slug": "bali",
+    "region": "Asia",
     "center": [
-      20.4,
-      -86.9
+      -8.3,
+      115.1
     ],
     "bounds": [
       [
-        20.2,
-        -87.1
+        -8.8,
+        114.4
       ],
       [
-        20.6,
-        -86.7
+        -8.0,
+        115.7
       ]
     ],
-    "description": "World-renowned drift diving through vibrant coral reefs with excellent visibility.",
+    "description": "Liberty wreck at Tulamben, mola mola encounters, and manta rays at Nusa Penida.",
     "overviewFile": "overview.md",
-    "countryCode": "MX"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Puerto Vallarta",
-    "slug": "puerto-vallarta",
-    "region": "North America",
+    "name": "Banda Sea",
+    "slug": "banda-sea",
+    "region": "Asia",
     "center": [
-      20.6,
-      -105.45
+      -4.57,
+      129.87
     ],
     "bounds": [
       [
-        20.4,
-        -105.8
+        -5.65,
+        129.6
       ],
       [
-        20.85,
-        -105.2
+        -4.35,
+        130.4
       ]
     ],
-    "description": "Banderas Bay diving centered on the Los Arcos marine park and granite pinnacles, with offshore seamounts for seasonal humpback whale and giant manta encounters.",
+    "description": "Historic spice island archipelago with the celebrated Lava Flow coral recovery site, hammerhead sharks at Jackpot pinnacle, Mandarin fish at Maulana, and the sea snake-rich volcanic walls of remote Manuk Island.",
     "overviewFile": "overview.md",
-    "countryCode": "MX"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Bermuda",
-    "slug": "bermuda",
-    "region": "Atlantic",
+    "name": "Gili Islands",
+    "slug": "gili-islands",
+    "region": "Asia",
     "center": [
-      32.3,
-      -64.8
+      -8.35,
+      116.0
     ],
     "bounds": [
       [
-        32.0,
-        -65.0
+        -8.4,
+        115.95
       ],
       [
-        32.5,
-        -64.5
+        -8.3,
+        116.05
       ]
     ],
-    "description": "World-class shipwreck diving, coral reefs, and mysterious blue holes.",
+    "description": "Turtle encounters, coral reef diving, and beginner-friendly sites off Lombok.",
     "overviewFile": "overview.md",
-    "countryCode": "BM"
+    "countryCode": "ID",
+    "parentSlug": "lombok"
   },
   {
-    "name": "Monterey Bay",
-    "slug": "monterey-bay",
-    "region": "North America",
+    "name": "Halmahera",
+    "slug": "halmahera",
+    "region": "Asia",
     "center": [
-      36.6002,
-      -121.9
+      1.0,
+      128.0
     ],
     "bounds": [
       [
-        36.5,
-        -122.0
+        -0.5,
+        127.0
       ],
       [
-        36.7,
-        -121.8
+        2.5,
+        129.0
       ]
     ],
-    "description": "World-famous kelp forest diving with incredible marine biodiversity.",
+    "description": "North Maluku's unexplored diving frontier with WWII wrecks, vibrant soft coral walls, whale shark encounters, and the unique marine biodiversity of the Halmahera Sea.",
     "overviewFile": "overview.md",
-    "countryCode": "US"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "California Channel Islands",
-    "slug": "california-channel-islands",
-    "region": "North America",
+    "name": "Koh Tao",
+    "slug": "koh-tao",
+    "region": "Asia",
     "center": [
-      34.0,
-      -119.5
+      10.1,
+      99.8
     ],
     "bounds": [
-      [
-        33.0,
-        -120.5
-      ],
-      [
-        35.0,
-        -118.5
-      ]
-    ],
-    "description": "Giant kelp forests, sea lions, and diverse cold-water marine species.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Vancouver Island",
-    "slug": "vancouver-island",
-    "region": "North America",
-    "center": [
-      49.5,
-      -126.0
-    ],
-    "bounds": [
-      [
-        48.0,
-        -128.5
-      ],
-      [
-        51.0,
-        -123.0
-      ]
-    ],
-    "description": "Premier cold-water diving with wolf eels, giant Pacific octopus, and colorful anemones.",
-    "overviewFile": "overview.md",
-    "countryCode": "CA"
-  },
-  {
-    "name": "La Paz & Sea of Cortez",
-    "slug": "la-paz-sea-of-cortez",
-    "region": "North America",
-    "center": [
-      24.1,
-      -110.3
-    ],
-    "bounds": [
-      [
-        22.0,
-        -112.0
-      ],
-      [
-        26.0,
-        -108.0
-      ]
-    ],
-    "description": "Jacques Cousteau's 'World's Aquarium' with sea lions, whale sharks, and diverse marine life.",
-    "overviewFile": "overview.md",
-    "countryCode": "MX"
-  },
-  {
-    "name": "Los Cabos",
-    "slug": "los-cabos",
-    "region": "North America",
-    "center": [
-      22.93,
-      -109.85
-    ],
-    "bounds": [
-      [
-        22.8,
-        -110.05
-      ],
-      [
-        23.1,
-        -109.45
-      ]
-    ],
-    "description": "Land's End diving with sand falls, sea lion colonies, and seasonal hammerhead and whale shark encounters at the tip of Baja California.",
-    "overviewFile": "overview.md",
-    "countryCode": "MX"
-  },
-  {
-    "name": "Cabo Pulmo",
-    "slug": "cabo-pulmo",
-    "region": "North America",
-    "center": [
-      23.44,
-      -109.42
-    ],
-    "bounds": [
-      [
-        23.35,
-        -109.55
-      ],
-      [
-        23.55,
-        -109.35
-      ]
-    ],
-    "description": "UNESCO World Heritage marine park with the only living coral reef in the Sea of Cortez, famous for massive jack tornado formations and reef sharks.",
-    "overviewFile": "overview.md",
-    "countryCode": "MX"
-  },
-  {
-    "name": "Florida Keys",
-    "slug": "florida-keys",
-    "region": "North America",
-    "center": [
-      24.7,
-      -81.0
-    ],
-    "bounds": [
-      [
-        24.3,
-        -82.0
-      ],
-      [
-        25.5,
-        -80.0
-      ]
-    ],
-    "description": "Coral reefs, wreck trails, and marine sanctuaries in crystal-clear tropical waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "North Carolina",
-    "slug": "north-carolina",
-    "region": "North America",
-    "center": [
-      35.0,
-      -76.0
-    ],
-    "bounds": [
-      [
-        33.5,
-        -77.0
-      ],
-      [
-        36.5,
-        -75.0
-      ]
-    ],
-    "description": "WWII wrecks and sand tiger shark encounters in the 'Graveyard of the Atlantic'.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Great Lakes",
-    "slug": "great-lakes",
-    "region": "North America",
-    "center": [
-      45.0,
-      -84.0
-    ],
-    "bounds": [
-      [
-        41.0,
-        -93.0
-      ],
-      [
-        49.0,
-        -75.0
-      ]
-    ],
-    "description": "Freshwater wreck diving with historic ships preserved in cold, clear waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Dry Tortugas",
-    "slug": "dry-tortugas",
-    "region": "North America",
-    "center": [
-      24.6,
-      -82.9
-    ],
-    "bounds": [
-      [
-        24.5,
-        -83.0
-      ],
-      [
-        24.7,
-        -82.8
-      ]
-    ],
-    "description": "Pristine reefs and protected marine park with incredible biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Newfoundland",
-    "slug": "newfoundland",
-    "region": "North America",
-    "center": [
-      49.0,
-      -56.0
-    ],
-    "bounds": [
-      [
-        46.5,
-        -60.0
-      ],
-      [
-        51.5,
-        -52.0
-      ]
-    ],
-    "description": "Iceberg diving, historic shipwrecks, and cold-water marine life.",
-    "overviewFile": "overview.md",
-    "countryCode": "CA"
-  },
-  {
-    "name": "Galápagos Islands",
-    "slug": "galapagos-islands",
-    "region": "South America",
-    "center": [
-      -0.7,
-      -90.5
-    ],
-    "bounds": [
-      [
-        -2.0,
-        -92.0
-      ],
-      [
-        1.0,
-        -89.0
-      ]
-    ],
-    "description": "Legendary encounters with hammerhead schools, whale sharks, sea lions, and marine iguanas.",
-    "overviewFile": "overview.md",
-    "countryCode": "EC"
-  },
-  {
-    "name": "Hawaii Big Island",
-    "slug": "hawaii-big-island",
-    "region": "Pacific",
-    "center": [
-      19.5,
-      -155.5
-    ],
-    "bounds": [
-      [
-        18.9,
-        -156.1
-      ],
-      [
-        20.3,
-        -154.8
-      ]
-    ],
-    "description": "Famous manta ray night dives, lava tubes, and volcanic underwater landscapes.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Socorro Islands",
-    "slug": "socorro-islands",
-    "region": "Pacific",
-    "center": [
-      18.9,
-      -111.0
-    ],
-    "bounds": [
-      [
-        18.0,
-        -112.2
-      ],
-      [
-        19.5,
-        -110.0
-      ]
-    ],
-    "description": "Remote Pacific paradise with giant manta rays, humpback whales, and massive shark schools.",
-    "overviewFile": "overview.md",
-    "countryCode": "MX"
-  },
-  {
-    "name": "Cocos Island",
-    "slug": "cocos-island",
-    "region": "Pacific",
-    "center": [
-      5.5,
-      -87.0
-    ],
-    "bounds": [
-      [
-        5.0,
-        -87.5
-      ],
-      [
-        6.0,
-        -86.5
-      ]
-    ],
-    "description": "Ultimate hammerhead shark aggregation site and deep-sea pelagic encounters.",
-    "overviewFile": "overview.md",
-    "countryCode": "CR"
-  },
-  {
-    "name": "Palau",
-    "slug": "palau",
-    "region": "Pacific",
-    "center": [
-      7.5,
-      134.5
-    ],
-    "bounds": [
-      [
-        6.0,
-        131.0
-      ],
-      [
-        9.0,
-        135.0
-      ]
-    ],
-    "description": "WWII wrecks, Blue Corner drift dives, and incredible shark encounters.",
-    "overviewFile": "overview.md",
-    "countryCode": "PW"
-  },
-  {
-    "name": "Fiji",
-    "slug": "fiji",
-    "region": "Pacific",
-    "center": [
-      -17.7,
-      178.0
-    ],
-    "bounds": [
-      [
-        -21.0,
-        176.0
-      ],
-      [
-        -12.0,
-        -179.0
-      ]
-    ],
-    "description": "Soft coral capital of the world with vibrant reefs and thrilling shark dives.",
-    "overviewFile": "overview.md",
-    "countryCode": "FJ"
-  },
-  {
-    "name": "French Polynesia",
-    "slug": "french-polynesia",
-    "region": "Pacific",
-    "center": [
-      -15.0,
-      -140.0
-    ],
-    "bounds": [
-      [
-        -28.0,
-        -155.0
-      ],
-      [
-        -7.0,
-        -134.0
-      ]
-    ],
-    "description": "Shark walls, drift dives, and encounters with big pelagic species in pristine atolls.",
-    "overviewFile": "overview.md",
-    "countryCode": "PF"
-  },
-  {
-    "name": "Papua New Guinea",
-    "slug": "papua-new-guinea",
-    "region": "Pacific",
-    "center": [
-      -6.0,
-      147.0
-    ],
-    "bounds": [
-      [
-        -12.0,
-        140.0
-      ],
-      [
-        -1.0,
-        156.0
-      ]
-    ],
-    "description": "Remote pristine reefs, incredible biodiversity, and historic WWII wrecks.",
-    "overviewFile": "overview.md",
-    "countryCode": "PG"
-  },
-  {
-    "name": "Chuuk Lagoon",
-    "slug": "chuuk-lagoon",
-    "region": "Pacific",
-    "center": [
-      7.4,
-      151.8
-    ],
-    "bounds": [
-      [
-        7.0,
-        151.0
-      ],
-      [
-        8.0,
-        152.5
-      ]
-    ],
-    "description": "The world's greatest wreck diving destination with the WWII 'Ghost Fleet'.",
-    "overviewFile": "overview.md",
-    "countryCode": "FM"
-  },
-  {
-    "name": "Solomon Islands",
-    "slug": "solomon-islands",
-    "region": "Pacific",
-    "center": [
-      -8.0,
-      159.0
-    ],
-    "bounds": [
-      [
-        -12.0,
-        155.0
-      ],
-      [
-        -5.0,
-        167.0
-      ]
-    ],
-    "description": "WWII wrecks and pristine coral reefs in remote Pacific waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "SB"
-  },
-  {
-    "name": "Vanuatu",
-    "slug": "vanuatu",
-    "region": "Pacific",
-    "center": [
-      -16.0,
-      167.0
-    ],
-    "bounds": [
-      [
-        -21.0,
-        166.0
-      ],
-      [
-        -13.0,
-        171.0
-      ]
-    ],
-    "description": "Famous SS President Coolidge wreck dive and vibrant coral reefs.",
-    "overviewFile": "overview.md",
-    "countryCode": "VU"
-  },
-  {
-    "name": "Tonga",
-    "slug": "tonga",
-    "region": "Pacific",
-    "center": [
-      -20.0,
-      -175.0
-    ],
-    "bounds": [
-      [
-        -25.0,
-        -177.0
-      ],
-      [
-        -15.0,
-        -173.0
-      ]
-    ],
-    "description": "Seasonal humpback whale encounters and pristine Pacific coral reefs.",
-    "overviewFile": "overview.md",
-    "countryCode": "TO"
-  },
-  {
-    "name": "Micronesia - Yap",
-    "slug": "micronesia-yap",
-    "region": "Pacific",
-    "center": [
-      9.5,
-      138.1
-    ],
-    "bounds": [
-      [
-        9.0,
-        137.5
-      ],
       [
         10.0,
-        138.5
+        99.7
+      ],
+      [
+        10.2,
+        99.9
       ]
     ],
-    "description": "World-famous manta ray encounters, reef sharks, and unique cultural experiences.",
+    "description": "Affordable tropical diving, beginner-friendly sites, and pristine coral reefs.",
     "overviewFile": "overview.md",
-    "countryCode": "FM"
+    "countryCode": "TH",
+    "parentSlug": "thailand"
   },
   {
-    "name": "Marshall Islands",
-    "slug": "marshall-islands",
-    "region": "Pacific",
+    "name": "Komodo National Park",
+    "slug": "komodo-national-park",
+    "region": "Asia",
     "center": [
-      10.0,
-      167.0
+      -8.5,
+      119.5
     ],
     "bounds": [
       [
-        4.0,
-        160.0
+        -9.0,
+        119.0
       ],
       [
-        15.0,
-        173.0
+        -8.0,
+        120.0
       ]
     ],
-    "description": "WWII wrecks, pristine coral atolls, and Pacific pelagic encounters.",
+    "description": "Famous manta ray cleaning stations, strong currents, and incredible biodiversity.",
     "overviewFile": "overview.md",
-    "countryCode": "MH"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
+  },
+  {
+    "name": "Lembeh Strait",
+    "slug": "lembeh-strait",
+    "region": "Asia",
+    "center": [
+      1.5,
+      125.2
+    ],
+    "bounds": [
+      [
+        1.3,
+        125.0
+      ],
+      [
+        1.7,
+        125.4
+      ]
+    ],
+    "description": "World capital of macro diving with rare critters and unique marine species.",
+    "overviewFile": "overview.md",
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
+  },
+  {
+    "name": "Lombok",
+    "slug": "lombok",
+    "region": "Asia",
+    "center": [
+      -8.6,
+      116.3
+    ],
+    "bounds": [
+      [
+        -9.0,
+        115.8
+      ],
+      [
+        -8.2,
+        116.8
+      ]
+    ],
+    "description": "Muck diving, vibrant coral reefs, and potential hammerhead encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
     "name": "Maldives",
@@ -836,114 +323,142 @@
     "countryCode": "MV"
   },
   {
-    "name": "Raja Ampat",
-    "slug": "raja-ampat",
-    "region": "Asia",
-    "center": [
-      -0.5,
-      130.5
-    ],
-    "bounds": [
-      [
-        -2.5,
-        129.0
-      ],
-      [
-        1.0,
-        132.0
-      ]
-    ],
-    "description": "The world's highest marine biodiversity with remote pristine reefs and endemic species.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Sipadan",
-    "slug": "sipadan",
-    "region": "Asia",
-    "center": [
-      4.1,
-      118.6
-    ],
-    "bounds": [
-      [
-        4.0,
-        118.5
-      ],
-      [
-        4.2,
-        118.7
-      ]
-    ],
-    "description": "Legendary for barracuda tornadoes, green turtle encounters, and dramatic wall diving.",
-    "overviewFile": "overview.md",
-    "countryCode": "MY"
-  },
-  {
-    "name": "Komodo National Park",
-    "slug": "komodo-national-park",
-    "region": "Asia",
-    "center": [
-      -8.5,
-      119.5
-    ],
-    "bounds": [
-      [
-        -9.0,
-        119.0
-      ],
-      [
-        -8.0,
-        120.0
-      ]
-    ],
-    "description": "Famous manta ray cleaning stations, strong currents, and incredible biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Lembeh Strait",
-    "slug": "lembeh-strait",
+    "name": "Manado & Bunaken",
+    "slug": "manado-bunaken",
     "region": "Asia",
     "center": [
       1.5,
-      125.2
+      124.8
     ],
     "bounds": [
       [
         1.3,
-        125.0
+        124.6
       ],
       [
         1.7,
-        125.4
+        125.0
       ]
     ],
-    "description": "World capital of macro diving with rare critters and unique marine species.",
+    "description": "Spectacular wall diving, macro life, and exceptional coral biodiversity.",
     "overviewFile": "overview.md",
-    "countryCode": "ID"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Thailand Similan Islands",
-    "slug": "thailand-similan-islands",
+    "name": "Okinawa",
+    "slug": "okinawa",
     "region": "Asia",
     "center": [
-      8.6,
-      97.6
+      26.2,
+      127.7
     ],
     "bounds": [
       [
-        8.0,
-        97.0
+        24.0,
+        122.9
       ],
       [
-        9.2,
-        98.2
+        28.0,
+        131.3
       ]
     ],
-    "description": "Pristine reefs with whale sharks, manta rays, and crystal-clear waters.",
+    "description": "WWII wrecks, coral reefs, and unique Japanese marine biodiversity.",
     "overviewFile": "overview.md",
-    "countryCode": "TH"
+    "countryCode": "JP",
+    "parentSlug": "japan"
+  },
+  {
+    "name": "Philippines Anilao",
+    "slug": "philippines-anilao",
+    "region": "Asia",
+    "center": [
+      13.8,
+      120.9
+    ],
+    "bounds": [
+      [
+        13.7,
+        120.8
+      ],
+      [
+        13.9,
+        121.0
+      ]
+    ],
+    "description": "World-class critter diving and macro photography paradise.",
+    "overviewFile": "overview.md",
+    "countryCode": "PH",
+    "parentSlug": "philippines"
+  },
+  {
+    "name": "Philippines Donsol",
+    "slug": "philippines-donsol",
+    "region": "Asia",
+    "center": [
+      12.75,
+      123.65
+    ],
+    "bounds": [
+      [
+        12.45,
+        123.5
+      ],
+      [
+        13.0,
+        123.85
+      ]
+    ],
+    "description": "Seasonal whale shark aggregations and snorkeling encounters, with manta ray diving at Manta Bowl and reef diving around Ticao and San Miguel Islands.",
+    "overviewFile": "overview.md",
+    "countryCode": "PH",
+    "parentSlug": "philippines"
+  },
+  {
+    "name": "Philippines Malapascua",
+    "slug": "philippines-malapascua",
+    "region": "Asia",
+    "center": [
+      11.3,
+      124.1
+    ],
+    "bounds": [
+      [
+        11.2,
+        124.0
+      ],
+      [
+        11.4,
+        124.2
+      ]
+    ],
+    "description": "Famous thresher shark encounters, shipwrecks, and vibrant coral reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "PH",
+    "parentSlug": "philippines"
+  },
+  {
+    "name": "Philippines Palawan",
+    "slug": "philippines-palawan",
+    "region": "Asia",
+    "center": [
+      9.5,
+      118.7
+    ],
+    "bounds": [
+      [
+        7.0,
+        117.0
+      ],
+      [
+        12.0,
+        120.0
+      ]
+    ],
+    "description": "WWII wrecks, limestone karst formations, and pristine coral reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "PH",
+    "parentSlug": "philippines"
   },
   {
     "name": "Philippines Tubbataha Reefs",
@@ -965,7 +480,77 @@
     ],
     "description": "Remote UNESCO World Heritage site with pristine reef walls and abundant sharks.",
     "overviewFile": "overview.md",
-    "countryCode": "PH"
+    "countryCode": "PH",
+    "parentSlug": "philippines"
+  },
+  {
+    "name": "Raja Ampat",
+    "slug": "raja-ampat",
+    "region": "Asia",
+    "center": [
+      -0.5,
+      130.5
+    ],
+    "bounds": [
+      [
+        -2.5,
+        129.0
+      ],
+      [
+        1.0,
+        132.0
+      ]
+    ],
+    "description": "The world's highest marine biodiversity with remote pristine reefs and endemic species.",
+    "overviewFile": "overview.md",
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
+  },
+  {
+    "name": "Sangalaki (Derawan Islands)",
+    "slug": "sangalaki",
+    "region": "Asia",
+    "center": [
+      2.19,
+      118.44
+    ],
+    "bounds": [
+      [
+        2.03,
+        118.18
+      ],
+      [
+        2.38,
+        118.68
+      ]
+    ],
+    "description": "Indonesia's manta ray capital with resident mantas at Sangalaki, the world's only accessible saltwater jellyfish lake at Kakaban, big fish drift dives at Maratua atoll, and macro-rich muck diving at Derawan.",
+    "overviewFile": "overview.md",
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
+  },
+  {
+    "name": "Sipadan",
+    "slug": "sipadan",
+    "region": "Asia",
+    "center": [
+      4.1,
+      118.6
+    ],
+    "bounds": [
+      [
+        4.0,
+        118.5
+      ],
+      [
+        4.2,
+        118.7
+      ]
+    ],
+    "description": "Legendary for barracuda tornadoes, green turtle encounters, and dramatic wall diving.",
+    "overviewFile": "overview.md",
+    "countryCode": "MY",
+    "parentSlug": "malaysia"
   },
   {
     "name": "Sri Lanka",
@@ -990,400 +575,121 @@
     "countryCode": "LK"
   },
   {
-    "name": "Gili Islands",
-    "slug": "gili-islands",
+    "name": "Sumbawa",
+    "slug": "sumbawa",
     "region": "Asia",
     "center": [
-      -8.35,
-      116.0
+      -8.25,
+      118.3
     ],
     "bounds": [
       [
-        -8.4,
-        115.95
-      ],
-      [
-        -8.3,
-        116.05
-      ]
-    ],
-    "description": "Turtle encounters, coral reef diving, and beginner-friendly sites off Lombok.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Manado & Bunaken",
-    "slug": "manado-bunaken",
-    "region": "Asia",
-    "center": [
-      1.5,
-      124.8
-    ],
-    "bounds": [
-      [
-        1.3,
-        124.6
-      ],
-      [
-        1.7,
-        125.0
-      ]
-    ],
-    "description": "Spectacular wall diving, macro life, and exceptional coral biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Bali",
-    "slug": "bali",
-    "region": "Asia",
-    "center": [
-      -8.3,
-      115.1
-    ],
-    "bounds": [
-      [
-        -8.8,
-        114.4
+        -8.5,
+        117.4
       ],
       [
         -8.0,
-        115.7
+        119.35
       ]
     ],
-    "description": "Liberty wreck at Tulamben, mola mola encounters, and manta rays at Nusa Penida.",
+    "description": "Indonesia's north Sumbawa coast with whale shark encounters in Saleh Bay, dramatic walls around Moyo Island marine park, volcanic geothermal vents at Sangeang Island, and sheltered muck diving at Satonda's sunken caldera.",
     "overviewFile": "overview.md",
-    "countryCode": "ID"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Lombok",
-    "slug": "lombok",
+    "name": "Thailand Similan Islands",
+    "slug": "thailand-similan-islands",
     "region": "Asia",
     "center": [
-      -8.6,
-      116.3
+      8.6,
+      97.6
     ],
     "bounds": [
       [
-        -9.0,
-        115.8
+        8.0,
+        97.0
       ],
       [
-        -8.2,
-        116.8
+        9.2,
+        98.2
       ]
     ],
-    "description": "Muck diving, vibrant coral reefs, and potential hammerhead encounters.",
+    "description": "Pristine reefs with whale sharks, manta rays, and crystal-clear waters.",
     "overviewFile": "overview.md",
-    "countryCode": "ID"
+    "countryCode": "TH",
+    "parentSlug": "thailand"
   },
   {
-    "name": "Koh Tao",
-    "slug": "koh-tao",
+    "name": "Triton Bay",
+    "slug": "triton-bay",
     "region": "Asia",
     "center": [
-      10.1,
-      99.8
+      -3.85,
+      134.1
     ],
     "bounds": [
       [
-        10.0,
-        99.7
+        -4.1,
+        133.7
       ],
       [
-        10.2,
-        99.9
+        -3.5,
+        134.5
       ]
     ],
-    "description": "Affordable tropical diving, beginner-friendly sites, and pristine coral reefs.",
+    "description": "Remote Indonesian dive frontier with whale sharks feeding on bagan nets, world-class soft corals, endemic flasher wrasse, and pygmy seahorses.",
     "overviewFile": "overview.md",
-    "countryCode": "TH"
+    "countryCode": "ID",
+    "parentSlug": "indonesia"
   },
   {
-    "name": "Philippines Palawan",
-    "slug": "philippines-palawan",
-    "region": "Asia",
-    "center": [
-      9.5,
-      118.7
-    ],
-    "bounds": [
-      [
-        7.0,
-        117.0
-      ],
-      [
-        12.0,
-        120.0
-      ]
-    ],
-    "description": "WWII wrecks, limestone karst formations, and pristine coral reefs.",
-    "overviewFile": "overview.md",
-    "countryCode": "PH"
-  },
-  {
-    "name": "Philippines Anilao",
-    "slug": "philippines-anilao",
-    "region": "Asia",
-    "center": [
-      13.8,
-      120.9
-    ],
-    "bounds": [
-      [
-        13.7,
-        120.8
-      ],
-      [
-        13.9,
-        121.0
-      ]
-    ],
-    "description": "World-class critter diving and macro photography paradise.",
-    "overviewFile": "overview.md",
-    "countryCode": "PH"
-  },
-  {
-    "name": "Philippines Malapascua",
-    "slug": "philippines-malapascua",
-    "region": "Asia",
-    "center": [
-      11.3,
-      124.1
-    ],
-    "bounds": [
-      [
-        11.2,
-        124.0
-      ],
-      [
-        11.4,
-        124.2
-      ]
-    ],
-    "description": "Famous thresher shark encounters, shipwrecks, and vibrant coral reefs.",
-    "overviewFile": "overview.md",
-    "countryCode": "PH"
-  },
-  {
-    "name": "Philippines Donsol",
-    "slug": "philippines-donsol",
-    "region": "Asia",
-    "center": [
-      12.75,
-      123.65
-    ],
-    "bounds": [
-      [
-        12.45,
-        123.5
-      ],
-      [
-        13.0,
-        123.85
-      ]
-    ],
-    "description": "Seasonal whale shark aggregations and snorkeling encounters, with manta ray diving at Manta Bowl and reef diving around Ticao and San Miguel Islands.",
-    "overviewFile": "overview.md",
-    "countryCode": "PH"
-  },
-  {
-    "name": "Okinawa",
-    "slug": "okinawa",
-    "region": "Asia",
-    "center": [
-      26.2,
-      127.7
-    ],
-    "bounds": [
-      [
-        24.0,
-        122.9
-      ],
-      [
-        28.0,
-        131.3
-      ]
-    ],
-    "description": "WWII wrecks, coral reefs, and unique Japanese marine biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "JP"
-  },
-  {
-    "name": "Andaman Islands",
-    "slug": "andaman-islands",
-    "region": "Asia",
-    "center": [
-      12.0,
-      92.8
-    ],
-    "bounds": [
-      [
-        10.5,
-        92.2
-      ],
-      [
-        13.7,
-        93.1
-      ]
-    ],
-    "description": "Untouched coral reefs and pristine pelagic encounters in remote Indian waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "IN"
-  },
-  {
-    "name": "Great Barrier Reef",
-    "slug": "great-barrier-reef",
-    "region": "Oceania",
-    "center": [
-      -18.2871,
-      147.6992
-    ],
-    "bounds": [
-      [
-        -24.0,
-        145.0
-      ],
-      [
-        -10.0,
-        154.0
-      ]
-    ],
-    "description": "The world's largest coral reef system with unparalleled marine diversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "AU"
-  },
-  {
-    "name": "Poor Knights Islands",
-    "slug": "poor-knights-islands",
-    "region": "Oceania",
-    "center": [
-      -35.5,
-      174.7
-    ],
-    "bounds": [
-      [
-        -35.6,
-        174.6
-      ],
-      [
-        -35.4,
-        174.8
-      ]
-    ],
-    "description": "Subtropical reefs, dramatic underwater caves, and diverse marine species.",
-    "overviewFile": "overview.md",
-    "countryCode": "NZ"
-  },
-  {
-    "name": "Lord Howe Island",
-    "slug": "lord-howe-island",
-    "region": "Oceania",
-    "center": [
-      -31.55,
-      159.1
-    ],
-    "bounds": [
-      [
-        -31.8,
-        158.9
-      ],
-      [
-        -31.4,
-        159.3
-      ]
-    ],
-    "description": "Pristine coral reefs with unique endemic species at the southernmost coral reef.",
-    "overviewFile": "overview.md",
-    "countryCode": "AU"
-  },
-  {
-    "name": "South Australia Neptune Islands",
-    "slug": "south-australia-neptune-islands",
-    "region": "Oceania",
-    "center": [
-      -35.3,
-      136.1
-    ],
-    "bounds": [
-      [
-        -35.5,
-        135.9
-      ],
-      [
-        -35.1,
-        136.3
-      ]
-    ],
-    "description": "Premier great white shark cage diving destination with crystal-clear waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "AU"
-  },
-  {
-    "name": "Ningaloo Reef",
-    "slug": "ningaloo-reef",
-    "region": "Oceania",
-    "center": [
-      -22.5,
-      113.8
-    ],
-    "bounds": [
-      [
-        -24.0,
-        113.0
-      ],
-      [
-        -21.7,
-        114.5
-      ]
-    ],
-    "description": "Whale shark encounters and pristine coral gardens in Western Australia.",
-    "overviewFile": "overview.md",
-    "countryCode": "AU"
-  },
-  {
-    "name": "Christmas Island",
-    "slug": "christmas-island",
-    "region": "Oceania",
-    "center": [
-      -10.5,
-      105.7
-    ],
-    "bounds": [
-      [
-        -10.6,
-        105.5
-      ],
-      [
-        -10.4,
-        105.8
-      ]
-    ],
-    "description": "Whale sharks, dramatic coral walls, and pelagic action in remote waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "CX"
-  },
-  {
-    "name": "Silfra Fissure",
-    "slug": "silfra-fissure",
+    "name": "France",
+    "slug": "france",
     "region": "Europe",
-    "center": [
-      64.2,
-      -21.1
-    ],
-    "bounds": [
-      [
-        64.1,
-        -21.2
-      ],
-      [
-        64.3,
-        -21.0
-      ]
-    ],
-    "description": "Dive between tectonic plates in crystal-clear glacial water with 100m+ visibility.",
-    "overviewFile": "overview.md",
+    "isGroup": true,
+    "description": "Protected Mediterranean marine parks with exceptional biodiversity.",
+    "countryCode": "FR"
+  },
+  {
+    "name": "Iceland",
+    "slug": "iceland",
+    "region": "Europe",
+    "isGroup": true,
+    "description": "Crystal-clear freshwater fissure diving between tectonic plates.",
     "countryCode": "IS"
+  },
+  {
+    "name": "Italy",
+    "slug": "italy",
+    "region": "Europe",
+    "isGroup": true,
+    "description": "Mediterranean marine reserves with rich biodiversity and volcanic underwater landscapes.",
+    "countryCode": "IT"
+  },
+  {
+    "name": "Norway",
+    "slug": "norway",
+    "region": "Europe",
+    "isGroup": true,
+    "description": "Cold-water diving with orcas, dramatic fjord walls, and Arctic marine life.",
+    "countryCode": "NO"
+  },
+  {
+    "name": "Portugal",
+    "slug": "portugal",
+    "region": "Europe",
+    "isGroup": true,
+    "description": "Atlantic volcanic island diving with pelagic encounters and rich marine life.",
+    "countryCode": "PT"
+  },
+  {
+    "name": "Scotland",
+    "slug": "scotland",
+    "region": "Europe",
+    "isGroup": true,
+    "description": "Historic wreck diving in some of the world's most famous scuttled fleets.",
+    "countryCode": "GB"
   },
   {
     "name": "Azores",
@@ -1405,95 +711,8 @@
     ],
     "description": "Atlantic paradise with blue sharks, mobula rays, and pristine volcanic formations.",
     "overviewFile": "overview.md",
-    "countryCode": "PT"
-  },
-  {
-    "name": "Scapa Flow",
-    "slug": "scapa-flow",
-    "region": "Europe",
-    "center": [
-      58.9,
-      -3.2
-    ],
-    "bounds": [
-      [
-        58.7,
-        -3.5
-      ],
-      [
-        59.1,
-        -2.9
-      ]
-    ],
-    "description": "Historic WWI German fleet wrecks in Scotland's premier cold-water diving destination.",
-    "overviewFile": "overview.md",
-    "countryCode": "GB"
-  },
-  {
-    "name": "Sardinia",
-    "slug": "sardinia",
-    "region": "Europe",
-    "center": [
-      40.0,
-      9.0
-    ],
-    "bounds": [
-      [
-        38.8,
-        8.1
-      ],
-      [
-        41.2,
-        9.9
-      ]
-    ],
-    "description": "Mediterranean caves, dramatic caverns, and historic shipwrecks in crystal-clear waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "IT"
-  },
-  {
-    "name": "Malta and Gozo",
-    "slug": "malta-and-gozo",
-    "region": "Europe",
-    "center": [
-      35.9,
-      14.4
-    ],
-    "bounds": [
-      [
-        35.7,
-        14.1
-      ],
-      [
-        36.1,
-        14.6
-      ]
-    ],
-    "description": "World-class cavern diving, historic wrecks, and exceptional Mediterranean visibility.",
-    "overviewFile": "overview.md",
-    "countryCode": "MT"
-  },
-  {
-    "name": "Norway Lofoten Islands",
-    "slug": "norway-lofoten-islands",
-    "region": "Europe",
-    "center": [
-      68.2,
-      13.6
-    ],
-    "bounds": [
-      [
-        67.5,
-        12.0
-      ],
-      [
-        68.9,
-        15.2
-      ]
-    ],
-    "description": "Arctic diving with cold-water reefs, historic wrecks, and seasonal orca encounters.",
-    "overviewFile": "overview.md",
-    "countryCode": "NO"
+    "countryCode": "PT",
+    "parentSlug": "portugal"
   },
   {
     "name": "Croatia",
@@ -1540,6 +759,143 @@
     "countryCode": "GR"
   },
   {
+    "name": "Malta and Gozo",
+    "slug": "malta-and-gozo",
+    "region": "Europe",
+    "center": [
+      35.9,
+      14.4
+    ],
+    "bounds": [
+      [
+        35.7,
+        14.1
+      ],
+      [
+        36.1,
+        14.6
+      ]
+    ],
+    "description": "World-class cavern diving, historic wrecks, and exceptional Mediterranean visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "MT"
+  },
+  {
+    "name": "Norway Lofoten Islands",
+    "slug": "norway-lofoten-islands",
+    "region": "Europe",
+    "center": [
+      68.2,
+      13.6
+    ],
+    "bounds": [
+      [
+        67.5,
+        12.0
+      ],
+      [
+        68.9,
+        15.2
+      ]
+    ],
+    "description": "Arctic diving with cold-water reefs, historic wrecks, and seasonal orca encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "NO",
+    "parentSlug": "norway"
+  },
+  {
+    "name": "Port-Cros",
+    "slug": "port-cros",
+    "region": "Europe",
+    "center": [
+      43.0,
+      6.4
+    ],
+    "bounds": [
+      [
+        42.95,
+        6.2
+      ],
+      [
+        43.1,
+        6.55
+      ]
+    ],
+    "description": "Europe's oldest marine reserve on France's Côte d'Azur, birthplace of modern scuba diving with over 50 dive sites and exceptional Mediterranean visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "FR",
+    "parentSlug": "france"
+  },
+  {
+    "name": "Sardinia",
+    "slug": "sardinia",
+    "region": "Europe",
+    "center": [
+      40.0,
+      9.0
+    ],
+    "bounds": [
+      [
+        38.8,
+        8.1
+      ],
+      [
+        41.2,
+        9.9
+      ]
+    ],
+    "description": "Mediterranean caves, dramatic caverns, and historic shipwrecks in crystal-clear waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "IT",
+    "parentSlug": "italy"
+  },
+  {
+    "name": "Scapa Flow",
+    "slug": "scapa-flow",
+    "region": "Europe",
+    "center": [
+      58.9,
+      -3.2
+    ],
+    "bounds": [
+      [
+        58.7,
+        -3.5
+      ],
+      [
+        59.1,
+        -2.9
+      ]
+    ],
+    "description": "Historic WWI German fleet wrecks in Scotland's premier cold-water diving destination.",
+    "overviewFile": "overview.md",
+    "countryCode": "GB",
+    "parentSlug": "scotland"
+  },
+  {
+    "name": "Silfra Fissure",
+    "slug": "silfra-fissure",
+    "region": "Europe",
+    "center": [
+      64.2,
+      -21.1
+    ],
+    "bounds": [
+      [
+        64.1,
+        -21.2
+      ],
+      [
+        64.3,
+        -21.0
+      ]
+    ],
+    "description": "Dive between tectonic plates in crystal-clear glacial water with 100m+ visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "IS",
+    "parentSlug": "iceland"
+  },
+  {
     "name": "Turkey",
     "slug": "turkey",
     "region": "Europe",
@@ -1562,48 +918,82 @@
     "countryCode": "TR"
   },
   {
-    "name": "Red Sea",
-    "slug": "red-sea",
-    "region": "Middle East",
+    "name": "Ustica",
+    "slug": "ustica",
+    "region": "Europe",
     "center": [
-      24.0,
-      36.0
+      38.71,
+      13.18
     ],
     "bounds": [
       [
-        12.0,
-        32.0
+        38.68,
+        13.14
       ],
       [
-        30.0,
-        43.0
+        38.74,
+        13.22
       ]
     ],
-    "description": "World-class diving with pristine coral reefs and exceptional visibility.",
+    "description": "Volcanic Mediterranean island and Italy's first marine reserve since 1986, with dramatic lava formations, archaeological sites, and exceptional biodiversity.",
     "overviewFile": "overview.md",
+    "countryCode": "IT",
+    "parentSlug": "italy"
+  },
+  {
+    "name": "Egypt",
+    "slug": "egypt",
+    "region": "Middle East",
+    "isGroup": true,
+    "description": "World-famous Red Sea diving with spectacular walls, wrecks, and coral gardens.",
     "countryCode": "EG"
   },
   {
-    "name": "Sudan Red Sea",
-    "slug": "sudan-red-sea",
+    "name": "Jordan",
+    "slug": "jordan",
+    "region": "Middle East",
+    "isGroup": true,
+    "description": "Red Sea diving with unique military wrecks and vibrant coral gardens.",
+    "countryCode": "JO"
+  },
+  {
+    "name": "Sudan",
+    "slug": "sudan",
+    "region": "Middle East",
+    "isGroup": true,
+    "description": "Remote and pristine Red Sea reefs with legendary shark encounters.",
+    "countryCode": "SD"
+  },
+  {
+    "name": "UAE",
+    "slug": "uae",
+    "region": "Middle East",
+    "isGroup": true,
+    "description": "Artificial reefs and accessible wreck diving in the Arabian Gulf.",
+    "countryCode": "AE"
+  },
+  {
+    "name": "Jordan - Aqaba",
+    "slug": "jordan-aqaba",
     "region": "Middle East",
     "center": [
-      20.0,
-      37.0
+      29.5,
+      35.0
     ],
     "bounds": [
       [
-        15.0,
-        34.0
+        29.3,
+        34.9
       ],
       [
-        22.0,
-        39.0
+        29.6,
+        35.1
       ]
     ],
-    "description": "Pristine Red Sea reefs, shark encounters, and WWII wrecks in remote waters.",
+    "description": "Red Sea diving with healthy coral reefs and accessible shore diving.",
     "overviewFile": "overview.md",
-    "countryCode": "SD"
+    "countryCode": "JO",
+    "parentSlug": "jordan"
   },
   {
     "name": "Oman",
@@ -1628,6 +1018,52 @@
     "countryCode": "OM"
   },
   {
+    "name": "Red Sea",
+    "slug": "red-sea",
+    "region": "Middle East",
+    "center": [
+      24.0,
+      36.0
+    ],
+    "bounds": [
+      [
+        12.0,
+        32.0
+      ],
+      [
+        30.0,
+        43.0
+      ]
+    ],
+    "description": "World-class diving with pristine coral reefs and exceptional visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "EG",
+    "parentSlug": "egypt"
+  },
+  {
+    "name": "Sudan Red Sea",
+    "slug": "sudan-red-sea",
+    "region": "Middle East",
+    "center": [
+      20.0,
+      37.0
+    ],
+    "bounds": [
+      [
+        15.0,
+        34.0
+      ],
+      [
+        22.0,
+        39.0
+      ]
+    ],
+    "description": "Pristine Red Sea reefs, shark encounters, and WWII wrecks in remote waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "SD",
+    "parentSlug": "sudan"
+  },
+  {
     "name": "UAE - Fujairah",
     "slug": "uae-fujairah",
     "region": "Middle East",
@@ -1647,73 +1083,8 @@
     ],
     "description": "Arabian Sea coral reefs and warm-water diving in the Gulf of Oman.",
     "overviewFile": "overview.md",
-    "countryCode": "AE"
-  },
-  {
-    "name": "Jordan - Aqaba",
-    "slug": "jordan-aqaba",
-    "region": "Middle East",
-    "center": [
-      29.5,
-      35.0
-    ],
-    "bounds": [
-      [
-        29.3,
-        34.9
-      ],
-      [
-        29.6,
-        35.1
-      ]
-    ],
-    "description": "Red Sea diving with healthy coral reefs and accessible shore diving.",
-    "overviewFile": "overview.md",
-    "countryCode": "JO"
-  },
-  {
-    "name": "Mozambique",
-    "slug": "mozambique",
-    "region": "Africa",
-    "center": [
-      -18.0,
-      35.0
-    ],
-    "bounds": [
-      [
-        -27.0,
-        30.0
-      ],
-      [
-        -10.0,
-        41.0
-      ]
-    ],
-    "description": "Manta rays, whale sharks, and pristine coral reefs along the East African coast.",
-    "overviewFile": "overview.md",
-    "countryCode": "MZ"
-  },
-  {
-    "name": "Tanzania",
-    "slug": "tanzania",
-    "region": "Africa",
-    "center": [
-      -6.0,
-      35.0
-    ],
-    "bounds": [
-      [
-        -12.0,
-        29.0
-      ],
-      [
-        -1.0,
-        41.0
-      ]
-    ],
-    "description": "Pemba and Mafia Islands offer whale sharks, untouched reefs, and incredible biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "TZ"
+    "countryCode": "AE",
+    "parentSlug": "uae"
   },
   {
     "name": "South Africa",
@@ -1735,7 +1106,98 @@
     ],
     "description": "Aliwal Shoal and Protea Banks offer ragged-tooth sharks, tiger sharks, and the sardine run.",
     "overviewFile": "overview.md",
-    "countryCode": "ZA"
+    "countryCode": "ZA",
+    "isGroup": true
+  },
+  {
+    "name": "Tanzania",
+    "slug": "tanzania",
+    "region": "Africa",
+    "center": [
+      -6.0,
+      35.0
+    ],
+    "bounds": [
+      [
+        -12.0,
+        29.0
+      ],
+      [
+        -1.0,
+        41.0
+      ]
+    ],
+    "description": "Pemba and Mafia Islands offer whale sharks, untouched reefs, and incredible biodiversity.",
+    "overviewFile": "overview.md",
+    "countryCode": "TZ",
+    "isGroup": true
+  },
+  {
+    "name": "Cape Town",
+    "slug": "cape-town",
+    "region": "Africa",
+    "center": [
+      -34.0,
+      18.5
+    ],
+    "bounds": [
+      [
+        -34.4,
+        18.3
+      ],
+      [
+        -33.7,
+        18.9
+      ]
+    ],
+    "description": "Unique kelp forest diving in the Great African Seaforest with over 13,000 endemic marine species, seven-gill cow sharks, and pyjama cat sharks.",
+    "overviewFile": "overview.md",
+    "countryCode": "ZA",
+    "parentSlug": "south-africa"
+  },
+  {
+    "name": "Djibouti",
+    "slug": "djibouti",
+    "region": "Africa",
+    "center": [
+      11.8,
+      42.6
+    ],
+    "bounds": [
+      [
+        10.9,
+        41.8
+      ],
+      [
+        12.7,
+        43.4
+      ]
+    ],
+    "description": "Whale shark encounters in the Gulf of Tadjoura and pristine Red Sea reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "DJ"
+  },
+  {
+    "name": "Kenya Coast",
+    "slug": "kenya-coast",
+    "region": "Africa",
+    "center": [
+      -4.35,
+      39.55
+    ],
+    "bounds": [
+      [
+        -4.7,
+        39.3
+      ],
+      [
+        -3.3,
+        40.2
+      ]
+    ],
+    "description": "East African coral gardens at Kisite-Mpunguti and Watamu Marine Parks with whale sharks, manta rays, sea turtles, and vibrant Indian Ocean reef life.",
+    "overviewFile": "overview.md",
+    "countryCode": "KE"
   },
   {
     "name": "Madagascar",
@@ -1760,26 +1222,48 @@
     "countryCode": "MG"
   },
   {
-    "name": "Zanzibar",
-    "slug": "zanzibar",
+    "name": "Mauritius",
+    "slug": "mauritius",
     "region": "Africa",
     "center": [
-      -6.1,
-      39.3
+      -20.3,
+      57.6
     ],
     "bounds": [
       [
-        -6.5,
-        39.0
+        -20.5,
+        57.3
       ],
       [
-        -5.7,
-        39.6
+        -19.9,
+        63.5
       ]
     ],
-    "description": "Coral reefs, green turtles, and seasonal whale shark encounters off Tanzania's coast.",
+    "description": "Historic shipwrecks, coral reefs, and diverse Indian Ocean marine biodiversity.",
     "overviewFile": "overview.md",
-    "countryCode": "TZ"
+    "countryCode": "MU"
+  },
+  {
+    "name": "Mozambique",
+    "slug": "mozambique",
+    "region": "Africa",
+    "center": [
+      -18.0,
+      35.0
+    ],
+    "bounds": [
+      [
+        -27.0,
+        30.0
+      ],
+      [
+        -10.0,
+        41.0
+      ]
+    ],
+    "description": "Manta rays, whale sharks, and pristine coral reefs along the East African coast.",
+    "overviewFile": "overview.md",
+    "countryCode": "MZ"
   },
   {
     "name": "Seychelles",
@@ -1804,48 +1288,1862 @@
     "countryCode": "SC"
   },
   {
-    "name": "Mauritius",
-    "slug": "mauritius",
+    "name": "Zanzibar",
+    "slug": "zanzibar",
     "region": "Africa",
     "center": [
-      -20.3,
-      57.6
+      -6.1,
+      39.3
     ],
     "bounds": [
       [
-        -20.5,
-        57.3
+        -6.5,
+        39.0
       ],
       [
-        -19.9,
-        63.5
+        -5.7,
+        39.6
       ]
     ],
-    "description": "Historic shipwrecks, coral reefs, and diverse Indian Ocean marine biodiversity.",
+    "description": "Coral reefs, green turtles, and seasonal whale shark encounters off Tanzania's coast.",
     "overviewFile": "overview.md",
-    "countryCode": "MU"
+    "countryCode": "TZ",
+    "parentSlug": "tanzania"
   },
   {
-    "name": "Djibouti",
-    "slug": "djibouti",
-    "region": "Africa",
+    "name": "Canada",
+    "slug": "canada",
+    "region": "North America",
+    "isGroup": true,
+    "description": "Cold-water diving with giant Pacific octopus, wolf eels, and Atlantic wrecks.",
+    "countryCode": "CA"
+  },
+  {
+    "name": "Hawaii",
+    "slug": "hawaii",
+    "region": "North America",
+    "isGroup": true,
+    "description": "Tropical Pacific diving with manta rays, pelagics, and volcanic reef formations.",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Mexico",
+    "slug": "mexico",
+    "region": "North America",
+    "isGroup": true,
+    "description": "From Caribbean reefs to Pacific pelagic encounters and Sea of Cortez adventures.",
+    "countryCode": "MX"
+  },
+  {
+    "name": "United States",
+    "slug": "us",
+    "region": "North America",
+    "isGroup": true,
+    "description": "Diverse diving from tropical reefs to cold-water kelp forests and historic wrecks.",
+    "countryCode": "US"
+  },
+  {
+    "name": "Alaska",
+    "slug": "alaska",
+    "region": "North America",
     "center": [
-      11.8,
-      42.6
+      58.3,
+      -134.4
     ],
     "bounds": [
       [
-        10.9,
-        41.8
+        54.0,
+        -170.0
       ],
       [
-        12.7,
-        43.4
+        63.0,
+        -130.0
       ]
     ],
-    "description": "Whale shark encounters in the Gulf of Tadjoura and pristine Red Sea reefs.",
+    "description": "Extreme cold-water diving in pristine wilderness waters with giant Pacific octopus, king crab, sea otters, Steller sea lions, and orca encounters amid dramatic underwater topography.",
     "overviewFile": "overview.md",
-    "countryCode": "DJ"
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "British Columbia",
+    "slug": "british-columbia",
+    "region": "North America",
+    "center": [
+      49.3,
+      -123.2
+    ],
+    "bounds": [
+      [
+        48.3,
+        -126.0
+      ],
+      [
+        52.0,
+        -122.0
+      ]
+    ],
+    "description": "Jacques Cousteau called BC waters the best temperate diving in the world. Features giant Pacific octopus, wolf eels, cloud sponge gardens, and the HMCS Saskatchewan artificial reef.",
+    "overviewFile": "overview.md",
+    "countryCode": "CA",
+    "parentSlug": "canada"
+  },
+  {
+    "name": "Cabo Pulmo",
+    "slug": "cabo-pulmo",
+    "region": "North America",
+    "center": [
+      23.44,
+      -109.42
+    ],
+    "bounds": [
+      [
+        23.35,
+        -109.55
+      ],
+      [
+        23.55,
+        -109.35
+      ]
+    ],
+    "description": "UNESCO World Heritage marine park with the only living coral reef in the Sea of Cortez, famous for massive jack tornado formations and reef sharks.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "California Channel Islands",
+    "slug": "california-channel-islands",
+    "region": "North America",
+    "center": [
+      34.0,
+      -119.5
+    ],
+    "bounds": [
+      [
+        33.0,
+        -120.5
+      ],
+      [
+        35.0,
+        -118.5
+      ]
+    ],
+    "description": "Giant kelp forests, sea lions, and diverse cold-water marine species.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Cozumel",
+    "slug": "cozumel",
+    "region": "North America",
+    "center": [
+      20.4,
+      -86.9
+    ],
+    "bounds": [
+      [
+        20.2,
+        -87.1
+      ],
+      [
+        20.6,
+        -86.7
+      ]
+    ],
+    "description": "World-renowned drift diving through vibrant coral reefs with excellent visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "Dry Tortugas",
+    "slug": "dry-tortugas",
+    "region": "North America",
+    "center": [
+      24.6,
+      -82.9
+    ],
+    "bounds": [
+      [
+        24.5,
+        -83.0
+      ],
+      [
+        24.7,
+        -82.8
+      ]
+    ],
+    "description": "Pristine reefs and protected marine park with incredible biodiversity.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Florida Keys",
+    "slug": "florida-keys",
+    "region": "North America",
+    "center": [
+      24.7,
+      -81.0
+    ],
+    "bounds": [
+      [
+        24.3,
+        -82.0
+      ],
+      [
+        25.5,
+        -80.0
+      ]
+    ],
+    "description": "Coral reefs, wreck trails, and marine sanctuaries in crystal-clear tropical waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Flower Garden Banks",
+    "slug": "flower-garden-banks",
+    "region": "North America",
+    "center": [
+      27.9,
+      -93.8
+    ],
+    "bounds": [
+      [
+        27.5,
+        -94.5
+      ],
+      [
+        28.3,
+        -93.0
+      ]
+    ],
+    "description": "The northernmost coral reefs in the continental US, sitting atop salt domes 100 miles offshore Texas in the Gulf of Mexico, with massive coral heads, manta rays, and whale sharks.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Great Lakes",
+    "slug": "great-lakes",
+    "region": "North America",
+    "center": [
+      45.0,
+      -84.0
+    ],
+    "bounds": [
+      [
+        41.0,
+        -93.0
+      ],
+      [
+        49.0,
+        -75.0
+      ]
+    ],
+    "description": "Freshwater wreck diving with historic ships preserved in cold, clear waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Hawaii - Kauai",
+    "slug": "hawaii-kauai",
+    "region": "North America",
+    "center": [
+      22.05,
+      -159.5
+    ],
+    "bounds": [
+      [
+        21.85,
+        -159.8
+      ],
+      [
+        22.25,
+        -159.28
+      ]
+    ],
+    "description": "The Garden Isle features dramatic lava tube formations, pristine reefs along the Na Pali Coast, and encounters with Hawaiian monk seals and spinner dolphins.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "hawaii"
+  },
+  {
+    "name": "Hawaii - Maui",
+    "slug": "hawaii-maui",
+    "region": "North America",
+    "center": [
+      20.8,
+      -156.3
+    ],
+    "bounds": [
+      [
+        20.5,
+        -156.7
+      ],
+      [
+        21.05,
+        -155.95
+      ]
+    ],
+    "description": "World-famous for the Molokini Crater, Maui offers exceptional diving with manta rays, green sea turtles, and seasonal humpback whale encounters in crystal-clear Hawaiian waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "hawaii"
+  },
+  {
+    "name": "Hawaii - Oahu",
+    "slug": "hawaii-oahu",
+    "region": "North America",
+    "center": [
+      21.47,
+      -158.0
+    ],
+    "bounds": [
+      [
+        21.25,
+        -158.3
+      ],
+      [
+        21.72,
+        -157.65
+      ]
+    ],
+    "description": "Oahu delivers diverse diving from shipwrecks and reef systems to shark dives and turtle cleaning stations, with easy access from Honolulu and the North Shore.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "hawaii"
+  },
+  {
+    "name": "Hawaii Big Island",
+    "slug": "hawaii-big-island",
+    "region": "North America",
+    "center": [
+      19.5,
+      -155.5
+    ],
+    "bounds": [
+      [
+        18.9,
+        -156.1
+      ],
+      [
+        20.3,
+        -154.8
+      ]
+    ],
+    "description": "Famous manta ray night dives, lava tubes, and volcanic underwater landscapes.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "hawaii"
+  },
+  {
+    "name": "La Paz & Sea of Cortez",
+    "slug": "la-paz-sea-of-cortez",
+    "region": "North America",
+    "center": [
+      24.1,
+      -110.3
+    ],
+    "bounds": [
+      [
+        22.0,
+        -112.0
+      ],
+      [
+        26.0,
+        -108.0
+      ]
+    ],
+    "description": "Jacques Cousteau's 'World's Aquarium' with sea lions, whale sharks, and diverse marine life.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "Los Cabos",
+    "slug": "los-cabos",
+    "region": "North America",
+    "center": [
+      22.93,
+      -109.85
+    ],
+    "bounds": [
+      [
+        22.8,
+        -110.05
+      ],
+      [
+        23.1,
+        -109.45
+      ]
+    ],
+    "description": "Land's End diving with sand falls, sea lion colonies, and seasonal hammerhead and whale shark encounters at the tip of Baja California.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "Monterey Bay",
+    "slug": "monterey-bay",
+    "region": "North America",
+    "center": [
+      36.6002,
+      -121.9
+    ],
+    "bounds": [
+      [
+        36.5,
+        -122.0
+      ],
+      [
+        36.7,
+        -121.8
+      ]
+    ],
+    "description": "World-famous kelp forest diving with incredible marine biodiversity.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "New England",
+    "slug": "new-england",
+    "region": "North America",
+    "center": [
+      41.5,
+      -70.5
+    ],
+    "bounds": [
+      [
+        40.5,
+        -72.0
+      ],
+      [
+        43.0,
+        -69.5
+      ]
+    ],
+    "description": "Historic wreck diving along the Massachusetts, Rhode Island, and Connecticut coasts, with lobster-filled boulder fields, seal encounters, and remnants of centuries of maritime history.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "New Jersey Shore",
+    "slug": "new-jersey",
+    "region": "North America",
+    "center": [
+      39.7,
+      -73.5
+    ],
+    "bounds": [
+      [
+        38.9,
+        -74.5
+      ],
+      [
+        40.5,
+        -73.0
+      ]
+    ],
+    "description": "The Wreck Capital of the Atlantic Coast, featuring hundreds of sunken vessels from WWII U-boat victims to modern artificial reefs, with sand tiger sharks and large pelagics.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Newfoundland",
+    "slug": "newfoundland",
+    "region": "North America",
+    "center": [
+      49.0,
+      -56.0
+    ],
+    "bounds": [
+      [
+        46.5,
+        -60.0
+      ],
+      [
+        51.5,
+        -52.0
+      ]
+    ],
+    "description": "Iceberg diving, historic shipwrecks, and cold-water marine life.",
+    "overviewFile": "overview.md",
+    "countryCode": "CA",
+    "parentSlug": "canada"
+  },
+  {
+    "name": "North Carolina",
+    "slug": "north-carolina",
+    "region": "North America",
+    "center": [
+      35.0,
+      -76.0
+    ],
+    "bounds": [
+      [
+        33.5,
+        -77.0
+      ],
+      [
+        36.5,
+        -75.0
+      ]
+    ],
+    "description": "WWII wrecks and sand tiger shark encounters in the 'Graveyard of the Atlantic'.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Nova Scotia",
+    "slug": "nova-scotia",
+    "region": "North America",
+    "center": [
+      44.6,
+      -63.5
+    ],
+    "bounds": [
+      [
+        43.3,
+        -66.5
+      ],
+      [
+        47.0,
+        -59.5
+      ]
+    ],
+    "description": "Cold Atlantic waters rich in maritime history, with WWII convoy wrecks, the Halifax Explosion aftermath, seal colonies, and the nutrient-rich Bay of Fundy with its extreme tides.",
+    "overviewFile": "overview.md",
+    "countryCode": "CA",
+    "parentSlug": "canada"
+  },
+  {
+    "name": "Puerto Vallarta",
+    "slug": "puerto-vallarta",
+    "region": "North America",
+    "center": [
+      20.6,
+      -105.45
+    ],
+    "bounds": [
+      [
+        20.4,
+        -105.8
+      ],
+      [
+        20.85,
+        -105.2
+      ]
+    ],
+    "description": "Banderas Bay diving centered on the Los Arcos marine park and granite pinnacles, with offshore seamounts for seasonal humpback whale and giant manta encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "Puget Sound",
+    "slug": "puget-sound",
+    "region": "North America",
+    "center": [
+      47.8,
+      -122.5
+    ],
+    "bounds": [
+      [
+        47.0,
+        -123.2
+      ],
+      [
+        48.8,
+        -122.0
+      ]
+    ],
+    "description": "Cold-water diving paradise in the Pacific Northwest with giant Pacific octopus, wolf eels, six-gill sharks, and colorful anemone gardens in nutrient-rich emerald waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "San Diego - La Jolla",
+    "slug": "san-diego-la-jolla",
+    "region": "North America",
+    "center": [
+      32.85,
+      -117.28
+    ],
+    "bounds": [
+      [
+        32.6,
+        -117.5
+      ],
+      [
+        33.1,
+        -117.1
+      ]
+    ],
+    "description": "Southern California kelp forest diving at its best, featuring La Jolla Cove, Wreck Alley, and abundant marine life including leopard sharks, bat rays, and giant sea bass.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Socorro Islands",
+    "slug": "socorro-islands",
+    "region": "North America",
+    "center": [
+      18.9,
+      -111.0
+    ],
+    "bounds": [
+      [
+        18.0,
+        -112.2
+      ],
+      [
+        19.5,
+        -110.0
+      ]
+    ],
+    "description": "Remote Pacific paradise with giant manta rays, humpback whales, and massive shark schools.",
+    "overviewFile": "overview.md",
+    "countryCode": "MX",
+    "parentSlug": "mexico"
+  },
+  {
+    "name": "South Florida",
+    "slug": "south-florida",
+    "region": "North America",
+    "center": [
+      26.1,
+      -80.1
+    ],
+    "bounds": [
+      [
+        25.5,
+        -80.5
+      ],
+      [
+        26.7,
+        -79.9
+      ]
+    ],
+    "description": "Year-round warm-water diving from Palm Beach to Miami with drift dives along the Gulf Stream, extensive artificial reef programs, and the Blue Heron Bridge macro paradise.",
+    "overviewFile": "overview.md",
+    "countryCode": "US",
+    "parentSlug": "us"
+  },
+  {
+    "name": "Vancouver Island",
+    "slug": "vancouver-island",
+    "region": "North America",
+    "center": [
+      49.5,
+      -126.0
+    ],
+    "bounds": [
+      [
+        48.0,
+        -128.5
+      ],
+      [
+        51.0,
+        -123.0
+      ]
+    ],
+    "description": "Premier cold-water diving with wolf eels, giant Pacific octopus, and colorful anemones.",
+    "overviewFile": "overview.md",
+    "countryCode": "CA",
+    "parentSlug": "canada"
+  },
+  {
+    "name": "Belize",
+    "slug": "belize",
+    "region": "Central America",
+    "isGroup": true,
+    "description": "The world's second-largest barrier reef with the iconic Great Blue Hole.",
+    "countryCode": "BZ"
+  },
+  {
+    "name": "Costa Rica",
+    "slug": "costa-rica",
+    "region": "Central America",
+    "isGroup": true,
+    "description": "Remote Pacific island diving with massive pelagic aggregations.",
+    "countryCode": "CR"
+  },
+  {
+    "name": "Honduras",
+    "slug": "honduras",
+    "region": "Central America",
+    "isGroup": true,
+    "description": "Caribbean reef diving and whale shark encounters on the Mesoamerican Barrier Reef.",
+    "countryCode": "HN"
+  },
+  {
+    "name": "Panama",
+    "slug": "panama",
+    "region": "Central America",
+    "isGroup": true,
+    "description": "Caribbean and Pacific diving with rich biodiversity in national marine parks.",
+    "countryCode": "PA"
+  },
+  {
+    "name": "Belize Barrier Reef",
+    "slug": "belize-barrier-reef",
+    "region": "Central America",
+    "center": [
+      16.7,
+      -88.0
+    ],
+    "bounds": [
+      [
+        15.5,
+        -89.0
+      ],
+      [
+        18.5,
+        -87.0
+      ]
+    ],
+    "description": "Home to the famous Blue Hole and spectacular reef walls with abundant marine life.",
+    "overviewFile": "overview.md",
+    "countryCode": "BZ",
+    "parentSlug": "belize"
+  },
+  {
+    "name": "Bocas del Toro",
+    "slug": "bocas-del-toro",
+    "region": "Central America",
+    "center": [
+      9.35,
+      -82.25
+    ],
+    "bounds": [
+      [
+        9.1,
+        -82.4
+      ],
+      [
+        9.5,
+        -81.9
+      ]
+    ],
+    "description": "Panama's Caribbean archipelago with diverse coral gardens, sea grass beds, mangrove channels, and encounters with green sea turtles and nurse sharks.",
+    "overviewFile": "overview.md",
+    "countryCode": "PA",
+    "parentSlug": "panama"
+  },
+  {
+    "name": "Cocos Island",
+    "slug": "cocos-island",
+    "region": "Central America",
+    "center": [
+      5.5,
+      -87.0
+    ],
+    "bounds": [
+      [
+        5.0,
+        -87.5
+      ],
+      [
+        6.0,
+        -86.5
+      ]
+    ],
+    "description": "Ultimate hammerhead shark aggregation site and deep-sea pelagic encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "CR",
+    "parentSlug": "costa-rica"
+  },
+  {
+    "name": "Coiba National Park",
+    "slug": "coiba-national-park",
+    "region": "Central America",
+    "center": [
+      7.5,
+      -81.75
+    ],
+    "bounds": [
+      [
+        7.1,
+        -82.0
+      ],
+      [
+        7.95,
+        -81.3
+      ]
+    ],
+    "description": "Panama's UNESCO marine park dubbed the 'Central American Galápagos' with whale sharks, giant mantas, hammerheads, and pristine Pacific reef systems.",
+    "overviewFile": "overview.md",
+    "countryCode": "PA",
+    "parentSlug": "panama"
+  },
+  {
+    "name": "Roatán",
+    "slug": "roatan",
+    "region": "Central America",
+    "center": [
+      16.32,
+      -86.53
+    ],
+    "bounds": [
+      [
+        16.24,
+        -86.63
+      ],
+      [
+        16.39,
+        -86.48
+      ]
+    ],
+    "description": "Honduras Bay Island with the Mesoamerican Barrier Reef, offering pristine walls, channels, and over 100 dive sites with exceptional visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "HN",
+    "parentSlug": "honduras"
+  },
+  {
+    "name": "Utila",
+    "slug": "utila",
+    "region": "Central America",
+    "center": [
+      16.1,
+      -86.9
+    ],
+    "bounds": [
+      [
+        16.0,
+        -87.0
+      ],
+      [
+        16.2,
+        -86.8
+      ]
+    ],
+    "description": "Famous for whale shark encounters and affordable diving in Honduras.",
+    "overviewFile": "overview.md",
+    "countryCode": "HN",
+    "parentSlug": "honduras"
+  },
+  {
+    "name": "Dutch Caribbean",
+    "slug": "dutch-caribbean",
+    "region": "Caribbean",
+    "isGroup": true,
+    "description": "Shore diving paradise with pristine reefs across the ABC islands and Windward Antilles."
+  },
+  {
+    "name": "Eastern Caribbean",
+    "slug": "eastern-caribbean",
+    "region": "Caribbean",
+    "isGroup": true,
+    "description": "Volcanic island diving with dramatic underwater topography and vibrant reefs."
+  },
+  {
+    "name": "French Antilles",
+    "slug": "french-antilles",
+    "region": "Caribbean",
+    "isGroup": true,
+    "description": "Caribbean marine parks with rich Creole diving culture and diverse reef systems."
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "slug": "antigua-and-barbuda",
+    "region": "Caribbean",
+    "center": [
+      17.08,
+      -61.8
+    ],
+    "bounds": [
+      [
+        16.9,
+        -62.0
+      ],
+      [
+        17.75,
+        -61.65
+      ]
+    ],
+    "description": "Pillars of Hercules rock formations, Cades Reef marine park, and historic shipwrecks in the waters of Nelson's Dockyard.",
+    "overviewFile": "overview.md",
+    "countryCode": "AG",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Aruba",
+    "slug": "aruba",
+    "region": "Caribbean",
+    "center": [
+      12.51,
+      -69.97
+    ],
+    "bounds": [
+      [
+        12.4,
+        -70.07
+      ],
+      [
+        12.63,
+        -69.87
+      ]
+    ],
+    "description": "The SS Antilla — one of the largest wreck dives in the Caribbean — plus pristine reefs, completing the famous ABC island diving trio.",
+    "overviewFile": "overview.md",
+    "countryCode": "AW",
+    "parentSlug": "dutch-caribbean"
+  },
+  {
+    "name": "Bahamas",
+    "slug": "bahamas",
+    "region": "Caribbean",
+    "center": [
+      24.25,
+      -76.0
+    ],
+    "bounds": [
+      [
+        22.0,
+        -80.0
+      ],
+      [
+        27.0,
+        -72.0
+      ]
+    ],
+    "description": "Crystal clear waters with blue holes, sharks, and pristine coral reefs including Tiger Beach.",
+    "overviewFile": "overview.md",
+    "countryCode": "BS"
+  },
+  {
+    "name": "Barbados",
+    "slug": "barbados",
+    "region": "Caribbean",
+    "center": [
+      13.18,
+      -59.55
+    ],
+    "bounds": [
+      [
+        13.04,
+        -59.67
+      ],
+      [
+        13.34,
+        -59.42
+      ]
+    ],
+    "description": "Carlisle Bay's six shore-accessible wrecks, sea turtle encounters on every dive, and healthy Atlantic-side reef systems.",
+    "overviewFile": "overview.md",
+    "countryCode": "BB",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Bonaire",
+    "slug": "bonaire",
+    "region": "Caribbean",
+    "center": [
+      12.1836,
+      -68.3177
+    ],
+    "bounds": [
+      [
+        12.02,
+        -68.42
+      ],
+      [
+        12.31,
+        -68.22
+      ]
+    ],
+    "description": "A Caribbean island known for its pristine coral reefs and excellent shore diving opportunities.",
+    "overviewFile": "overview.md",
+    "countryCode": "BQ",
+    "parentSlug": "dutch-caribbean"
+  },
+  {
+    "name": "British Virgin Islands",
+    "slug": "british-virgin-islands",
+    "region": "Caribbean",
+    "center": [
+      18.5,
+      -64.5
+    ],
+    "bounds": [
+      [
+        18.0,
+        -65.0
+      ],
+      [
+        19.0,
+        -64.0
+      ]
+    ],
+    "description": "Home to the famous RMS Rhone wreck and excellent reef diving.",
+    "overviewFile": "overview.md",
+    "countryCode": "VG"
+  },
+  {
+    "name": "Cayman Islands",
+    "slug": "cayman-islands",
+    "region": "Caribbean",
+    "center": [
+      19.35,
+      -81.25
+    ],
+    "bounds": [
+      [
+        19.0,
+        -82.0
+      ],
+      [
+        19.8,
+        -79.7
+      ]
+    ],
+    "description": "World-class wall dives, excellent visibility, and the famous Stingray City.",
+    "overviewFile": "overview.md",
+    "countryCode": "KY"
+  },
+  {
+    "name": "Curacao",
+    "slug": "curacao",
+    "region": "Caribbean",
+    "center": [
+      12.221,
+      -69.0103
+    ],
+    "bounds": [
+      [
+        12.0679,
+        -69.1586
+      ],
+      [
+        12.374,
+        -68.8619
+      ]
+    ],
+    "description": "Dutch Caribbean paradise offering world-class shore diving with colorful coral reefs, historic wrecks, and diverse marine life including sea turtles and tropical fish. Known for crystal-clear waters and excellent visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "CW",
+    "parentSlug": "dutch-caribbean"
+  },
+  {
+    "name": "Dominica",
+    "slug": "dominica",
+    "region": "Caribbean",
+    "center": [
+      15.42,
+      -61.35
+    ],
+    "bounds": [
+      [
+        15.2,
+        -61.5
+      ],
+      [
+        15.65,
+        -61.2
+      ]
+    ],
+    "description": "The 'Nature Isle' of the Caribbean with volcanic underwater hot springs, Champagne Reef's bubble dive, and sperm whale encounters year-round.",
+    "overviewFile": "overview.md",
+    "countryCode": "DM",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Dominican Republic",
+    "slug": "dominican-republic",
+    "region": "Caribbean",
+    "center": [
+      18.75,
+      -69.95
+    ],
+    "bounds": [
+      [
+        17.5,
+        -72.0
+      ],
+      [
+        20.0,
+        -68.3
+      ]
+    ],
+    "description": "Silver Bank humpback whale encounters, Catalina Island wall dives, Bayahibe reef systems, and the historic wrecks of La Caleta.",
+    "overviewFile": "overview.md",
+    "countryCode": "DO"
+  },
+  {
+    "name": "Grenada",
+    "slug": "grenada",
+    "region": "Caribbean",
+    "center": [
+      12.12,
+      -61.68
+    ],
+    "bounds": [
+      [
+        11.98,
+        -61.8
+      ],
+      [
+        12.24,
+        -61.58
+      ]
+    ],
+    "description": "Home to the Bianca C — the 'Titanic of the Caribbean' — and the world's first Underwater Sculpture Park, with pristine reefs and volcanic formations.",
+    "overviewFile": "overview.md",
+    "countryCode": "GD",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Guadeloupe",
+    "slug": "guadeloupe",
+    "region": "Caribbean",
+    "center": [
+      16.2,
+      -61.55
+    ],
+    "bounds": [
+      [
+        15.85,
+        -61.8
+      ],
+      [
+        16.5,
+        -61.15
+      ]
+    ],
+    "description": "Jacques Cousteau Reserve at Pigeon Island with exceptional marine biodiversity, volcanic reef formations, and France's premier Caribbean diving.",
+    "overviewFile": "overview.md",
+    "countryCode": "GP",
+    "parentSlug": "french-antilles"
+  },
+  {
+    "name": "Jamaica",
+    "slug": "jamaica",
+    "region": "Caribbean",
+    "center": [
+      18.1,
+      -77.3
+    ],
+    "bounds": [
+      [
+        17.7,
+        -78.4
+      ],
+      [
+        18.55,
+        -76.2
+      ]
+    ],
+    "description": "Montego Bay Marine Park, wreck diving off Kingston, vibrant coral walls, and the famous Widowmaker's Cave at Negril.",
+    "overviewFile": "overview.md",
+    "countryCode": "JM"
+  },
+  {
+    "name": "Martinique",
+    "slug": "martinique",
+    "region": "Caribbean",
+    "center": [
+      14.64,
+      -61.02
+    ],
+    "bounds": [
+      [
+        14.38,
+        -61.23
+      ],
+      [
+        14.88,
+        -60.81
+      ]
+    ],
+    "description": "Diamond Rock's dramatic pinnacle dive, historic St. Pierre wrecks from the 1902 eruption, and French Caribbean coral gardens.",
+    "overviewFile": "overview.md",
+    "countryCode": "MQ",
+    "parentSlug": "french-antilles"
+  },
+  {
+    "name": "Providencia Island",
+    "slug": "providencia-island",
+    "region": "Caribbean",
+    "center": [
+      13.35,
+      -81.37
+    ],
+    "bounds": [
+      [
+        13.3,
+        -81.45
+      ],
+      [
+        13.42,
+        -81.3
+      ]
+    ],
+    "description": "Remote Colombian Caribbean island with the third-largest coral reef in the world, a UNESCO Biosphere Reserve with pristine walls and exceptional visibility.",
+    "overviewFile": "overview.md",
+    "countryCode": "CO",
+    "parentSlug": "colombia",
+    "additionalParents": [
+      "caribbean"
+    ]
+  },
+  {
+    "name": "Puerto Rico",
+    "slug": "puerto-rico",
+    "region": "Caribbean",
+    "center": [
+      18.22,
+      -66.5
+    ],
+    "bounds": [
+      [
+        17.9,
+        -68.0
+      ],
+      [
+        18.55,
+        -65.2
+      ]
+    ],
+    "description": "Remote Desecheo and Mona Island walls, La Parguera's bioluminescent bay, and diverse Caribbean reef ecosystems across the archipelago.",
+    "overviewFile": "overview.md",
+    "countryCode": "PR"
+  },
+  {
+    "name": "Saba",
+    "slug": "saba",
+    "region": "Caribbean",
+    "center": [
+      17.63,
+      -63.23
+    ],
+    "bounds": [
+      [
+        17.6,
+        -63.3
+      ],
+      [
+        17.7,
+        -63.2
+      ]
+    ],
+    "description": "Dramatic pinnacle dives around an extinct volcanic island with pristine reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "BQ",
+    "parentSlug": "dutch-caribbean"
+  },
+  {
+    "name": "Sint Eustatius",
+    "slug": "sint-eustatius",
+    "region": "Caribbean",
+    "center": [
+      17.49,
+      -62.98
+    ],
+    "bounds": [
+      [
+        17.44,
+        -63.05
+      ],
+      [
+        17.54,
+        -62.92
+      ]
+    ],
+    "description": "Volcanic diving on the Dutch Caribbean's hidden gem with the Charles L. Brown wreck, pristine marine park, and historic anchor sites.",
+    "overviewFile": "overview.md",
+    "countryCode": "BQ",
+    "parentSlug": "dutch-caribbean"
+  },
+  {
+    "name": "St. Kitts and Nevis",
+    "slug": "st-kitts-and-nevis",
+    "region": "Caribbean",
+    "center": [
+      17.3,
+      -62.73
+    ],
+    "bounds": [
+      [
+        17.08,
+        -62.88
+      ],
+      [
+        17.42,
+        -62.52
+      ]
+    ],
+    "description": "MV River Taw wreck dive, volcanic reef formations, healthy coral gardens, and uncrowded sites in the Lesser Antilles.",
+    "overviewFile": "overview.md",
+    "countryCode": "KN",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "St. Lucia",
+    "slug": "st-lucia",
+    "region": "Caribbean",
+    "center": [
+      13.91,
+      -60.97
+    ],
+    "bounds": [
+      [
+        13.7,
+        -61.08
+      ],
+      [
+        14.12,
+        -60.87
+      ]
+    ],
+    "description": "Dramatic Piton wall dives, the famous Superman's Flight drift dive at Anse Chastanet, with healthy coral gardens beneath volcanic twin peaks.",
+    "overviewFile": "overview.md",
+    "countryCode": "LC",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "St. Vincent and the Grenadines",
+    "slug": "st-vincent-grenadines",
+    "region": "Caribbean",
+    "center": [
+      13.15,
+      -61.2
+    ],
+    "bounds": [
+      [
+        12.5,
+        -61.5
+      ],
+      [
+        13.4,
+        -61.1
+      ]
+    ],
+    "description": "Tobago Cays Marine Park with pristine coral gardens, volcanic black sand sites, drift dives, and rich critter life in uncrowded waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "VC",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Tobago",
+    "slug": "tobago",
+    "region": "Caribbean",
+    "center": [
+      11.22,
+      -60.67
+    ],
+    "bounds": [
+      [
+        11.1,
+        -60.9
+      ],
+      [
+        11.35,
+        -60.45
+      ]
+    ],
+    "description": "Speyside's world-class drift diving with the world's largest brain coral, giant manta rays, and nutrient-rich waters from South America.",
+    "overviewFile": "overview.md",
+    "countryCode": "TT",
+    "parentSlug": "eastern-caribbean"
+  },
+  {
+    "name": "Turks and Caicos",
+    "slug": "turks-and-caicos",
+    "region": "Caribbean",
+    "center": [
+      21.8,
+      -72.0
+    ],
+    "bounds": [
+      [
+        21.0,
+        -73.0
+      ],
+      [
+        22.5,
+        -71.0
+      ]
+    ],
+    "description": "Pristine wall dives, reef sharks, and crystal-clear warm Caribbean waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "TC"
+  },
+  {
+    "name": "US Virgin Islands",
+    "slug": "us-virgin-islands",
+    "region": "Caribbean",
+    "center": [
+      18.1,
+      -64.8
+    ],
+    "bounds": [
+      [
+        17.6,
+        -65.1
+      ],
+      [
+        18.45,
+        -64.5
+      ]
+    ],
+    "description": "Buck Island's underwater trail in St. Croix, historic wrecks off St. Thomas, and coral-rich walls across three main islands.",
+    "overviewFile": "overview.md",
+    "countryCode": "VI"
+  },
+  {
+    "name": "Colombia",
+    "slug": "colombia",
+    "region": "South America",
+    "isGroup": true,
+    "description": "Caribbean islands and remote Pacific pinnacles with pelagic encounters.",
+    "countryCode": "CO"
+  },
+  {
+    "name": "Ecuador",
+    "slug": "ecuador",
+    "region": "South America",
+    "isGroup": true,
+    "description": "Legendary Galapagos diving with hammerheads, mantas, and marine iguanas.",
+    "countryCode": "EC"
+  },
+  {
+    "name": "Galápagos Islands",
+    "slug": "galapagos-islands",
+    "region": "South America",
+    "center": [
+      -0.7,
+      -90.5
+    ],
+    "bounds": [
+      [
+        -2.0,
+        -92.0
+      ],
+      [
+        1.0,
+        -89.0
+      ]
+    ],
+    "description": "Legendary encounters with hammerhead schools, whale sharks, sea lions, and marine iguanas.",
+    "overviewFile": "overview.md",
+    "countryCode": "EC",
+    "parentSlug": "ecuador"
+  },
+  {
+    "name": "Micronesia",
+    "slug": "micronesia",
+    "region": "Pacific",
+    "isGroup": true,
+    "description": "World-class wreck diving and pristine reef systems across remote Pacific atolls."
+  },
+  {
+    "name": "South Pacific",
+    "slug": "south-pacific",
+    "region": "Pacific",
+    "isGroup": true,
+    "description": "Tropical island diving with shark encounters, coral gardens, and crystal-clear waters."
+  },
+  {
+    "name": "West Pacific",
+    "slug": "west-pacific",
+    "region": "Pacific",
+    "isGroup": true,
+    "description": "Remote Melanesian diving with exceptional WWII wrecks and pristine reefs."
+  },
+  {
+    "name": "Chuuk Lagoon",
+    "slug": "chuuk-lagoon",
+    "region": "Pacific",
+    "center": [
+      7.4,
+      151.8
+    ],
+    "bounds": [
+      [
+        7.0,
+        151.0
+      ],
+      [
+        8.0,
+        152.5
+      ]
+    ],
+    "description": "The world's greatest wreck diving destination with the WWII 'Ghost Fleet'.",
+    "overviewFile": "overview.md",
+    "countryCode": "FM",
+    "parentSlug": "micronesia"
+  },
+  {
+    "name": "Fiji",
+    "slug": "fiji",
+    "region": "Pacific",
+    "center": [
+      -17.7,
+      178.0
+    ],
+    "bounds": [
+      [
+        -21.0,
+        176.0
+      ],
+      [
+        -12.0,
+        -179.0
+      ]
+    ],
+    "description": "Soft coral capital of the world with vibrant reefs and thrilling shark dives.",
+    "overviewFile": "overview.md",
+    "countryCode": "FJ",
+    "parentSlug": "south-pacific"
+  },
+  {
+    "name": "French Polynesia",
+    "slug": "french-polynesia",
+    "region": "Pacific",
+    "center": [
+      -15.0,
+      -140.0
+    ],
+    "bounds": [
+      [
+        -28.0,
+        -155.0
+      ],
+      [
+        -7.0,
+        -134.0
+      ]
+    ],
+    "description": "Shark walls, drift dives, and encounters with big pelagic species in pristine atolls.",
+    "overviewFile": "overview.md",
+    "countryCode": "PF",
+    "parentSlug": "south-pacific"
+  },
+  {
+    "name": "Marshall Islands",
+    "slug": "marshall-islands",
+    "region": "Pacific",
+    "center": [
+      10.0,
+      167.0
+    ],
+    "bounds": [
+      [
+        4.0,
+        160.0
+      ],
+      [
+        15.0,
+        173.0
+      ]
+    ],
+    "description": "WWII wrecks, pristine coral atolls, and Pacific pelagic encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "MH",
+    "parentSlug": "micronesia"
+  },
+  {
+    "name": "Micronesia - Yap",
+    "slug": "micronesia-yap",
+    "region": "Pacific",
+    "center": [
+      9.5,
+      138.1
+    ],
+    "bounds": [
+      [
+        9.0,
+        137.5
+      ],
+      [
+        10.0,
+        138.5
+      ]
+    ],
+    "description": "World-famous manta ray encounters, reef sharks, and unique cultural experiences.",
+    "overviewFile": "overview.md",
+    "countryCode": "FM",
+    "parentSlug": "micronesia"
+  },
+  {
+    "name": "Palau",
+    "slug": "palau",
+    "region": "Pacific",
+    "center": [
+      7.5,
+      134.5
+    ],
+    "bounds": [
+      [
+        6.0,
+        131.0
+      ],
+      [
+        9.0,
+        135.0
+      ]
+    ],
+    "description": "WWII wrecks, Blue Corner drift dives, and incredible shark encounters.",
+    "overviewFile": "overview.md",
+    "countryCode": "PW",
+    "parentSlug": "micronesia"
+  },
+  {
+    "name": "Papua New Guinea",
+    "slug": "papua-new-guinea",
+    "region": "Pacific",
+    "center": [
+      -6.0,
+      147.0
+    ],
+    "bounds": [
+      [
+        -12.0,
+        140.0
+      ],
+      [
+        -1.0,
+        156.0
+      ]
+    ],
+    "description": "Remote pristine reefs, incredible biodiversity, and historic WWII wrecks.",
+    "overviewFile": "overview.md",
+    "countryCode": "PG",
+    "parentSlug": "west-pacific"
+  },
+  {
+    "name": "Solomon Islands",
+    "slug": "solomon-islands",
+    "region": "Pacific",
+    "center": [
+      -8.0,
+      159.0
+    ],
+    "bounds": [
+      [
+        -12.0,
+        155.0
+      ],
+      [
+        -5.0,
+        167.0
+      ]
+    ],
+    "description": "WWII wrecks and pristine coral reefs in remote Pacific waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "SB",
+    "parentSlug": "west-pacific"
+  },
+  {
+    "name": "Tonga",
+    "slug": "tonga",
+    "region": "Pacific",
+    "center": [
+      -20.0,
+      -175.0
+    ],
+    "bounds": [
+      [
+        -25.0,
+        -177.0
+      ],
+      [
+        -15.0,
+        -173.0
+      ]
+    ],
+    "description": "Seasonal humpback whale encounters and pristine Pacific coral reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "TO",
+    "parentSlug": "south-pacific"
+  },
+  {
+    "name": "Vanuatu",
+    "slug": "vanuatu",
+    "region": "Pacific",
+    "center": [
+      -16.0,
+      167.0
+    ],
+    "bounds": [
+      [
+        -21.0,
+        166.0
+      ],
+      [
+        -13.0,
+        171.0
+      ]
+    ],
+    "description": "Famous SS President Coolidge wreck dive and vibrant coral reefs.",
+    "overviewFile": "overview.md",
+    "countryCode": "VU",
+    "parentSlug": "south-pacific"
+  },
+  {
+    "name": "Australia",
+    "slug": "australia",
+    "region": "Oceania",
+    "isGroup": true,
+    "description": "From the Great Barrier Reef to temperate southern waters and remote island territories.",
+    "countryCode": "AU"
+  },
+  {
+    "name": "New Zealand",
+    "slug": "new-zealand",
+    "region": "Oceania",
+    "isGroup": true,
+    "description": "Subtropical island diving with unique marine reserves and diverse fish life.",
+    "countryCode": "NZ"
+  },
+  {
+    "name": "Christmas Island",
+    "slug": "christmas-island",
+    "region": "Oceania",
+    "center": [
+      -10.5,
+      105.7
+    ],
+    "bounds": [
+      [
+        -10.6,
+        105.5
+      ],
+      [
+        -10.4,
+        105.8
+      ]
+    ],
+    "description": "Whale sharks, dramatic coral walls, and pelagic action in remote waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "CX"
+  },
+  {
+    "name": "Great Barrier Reef",
+    "slug": "great-barrier-reef",
+    "region": "Oceania",
+    "center": [
+      -18.2871,
+      147.6992
+    ],
+    "bounds": [
+      [
+        -24.0,
+        145.0
+      ],
+      [
+        -10.0,
+        154.0
+      ]
+    ],
+    "description": "The world's largest coral reef system with unparalleled marine diversity.",
+    "overviewFile": "overview.md",
+    "countryCode": "AU",
+    "parentSlug": "australia"
+  },
+  {
+    "name": "Lord Howe Island",
+    "slug": "lord-howe-island",
+    "region": "Oceania",
+    "center": [
+      -31.55,
+      159.1
+    ],
+    "bounds": [
+      [
+        -31.8,
+        158.9
+      ],
+      [
+        -31.4,
+        159.3
+      ]
+    ],
+    "description": "Pristine coral reefs with unique endemic species at the southernmost coral reef.",
+    "overviewFile": "overview.md",
+    "countryCode": "AU",
+    "parentSlug": "australia"
+  },
+  {
+    "name": "Ningaloo Reef",
+    "slug": "ningaloo-reef",
+    "region": "Oceania",
+    "center": [
+      -22.5,
+      113.8
+    ],
+    "bounds": [
+      [
+        -24.0,
+        113.0
+      ],
+      [
+        -21.7,
+        114.5
+      ]
+    ],
+    "description": "Whale shark encounters and pristine coral gardens in Western Australia.",
+    "overviewFile": "overview.md",
+    "countryCode": "AU",
+    "parentSlug": "australia"
+  },
+  {
+    "name": "Poor Knights Islands",
+    "slug": "poor-knights-islands",
+    "region": "Oceania",
+    "center": [
+      -35.5,
+      174.7
+    ],
+    "bounds": [
+      [
+        -35.6,
+        174.6
+      ],
+      [
+        -35.4,
+        174.8
+      ]
+    ],
+    "description": "Subtropical reefs, dramatic underwater caves, and diverse marine species.",
+    "overviewFile": "overview.md",
+    "countryCode": "NZ",
+    "parentSlug": "new-zealand"
+  },
+  {
+    "name": "South Australia Neptune Islands",
+    "slug": "south-australia-neptune-islands",
+    "region": "Oceania",
+    "center": [
+      -35.3,
+      136.1
+    ],
+    "bounds": [
+      [
+        -35.5,
+        135.9
+      ],
+      [
+        -35.1,
+        136.3
+      ]
+    ],
+    "description": "Premier great white shark cage diving destination with crystal-clear waters.",
+    "overviewFile": "overview.md",
+    "countryCode": "AU",
+    "parentSlug": "australia"
   },
   {
     "name": "Greenland",
@@ -1892,949 +3190,25 @@
     "countryCode": "NO"
   },
   {
-    "name": "Roatán",
-    "slug": "roatan",
-    "region": "Caribbean",
+    "name": "Bermuda",
+    "slug": "bermuda",
+    "region": "Atlantic",
     "center": [
-      16.32,
-      -86.53
-    ],
-    "bounds": [
-      [
-        16.24,
-        -86.63
-      ],
-      [
-        16.39,
-        -86.48
-      ]
-    ],
-    "description": "Honduras Bay Island with the Mesoamerican Barrier Reef, offering pristine walls, channels, and over 100 dive sites with exceptional visibility.",
-    "overviewFile": "overview.md",
-    "countryCode": "HN"
-  },
-  {
-    "name": "Providencia Island",
-    "slug": "providencia-island",
-    "region": "Caribbean",
-    "center": [
-      13.35,
-      -81.37
-    ],
-    "bounds": [
-      [
-        13.3,
-        -81.45
-      ],
-      [
-        13.42,
-        -81.3
-      ]
-    ],
-    "description": "Remote Colombian Caribbean island with the third-largest coral reef in the world, a UNESCO Biosphere Reserve with pristine walls and exceptional visibility.",
-    "overviewFile": "overview.md",
-    "countryCode": "CO"
-  },
-  {
-    "name": "Bocas del Toro",
-    "slug": "bocas-del-toro",
-    "region": "Caribbean",
-    "center": [
-      9.35,
-      -82.25
-    ],
-    "bounds": [
-      [
-        9.1,
-        -82.4
-      ],
-      [
-        9.5,
-        -81.9
-      ]
-    ],
-    "description": "Panama's Caribbean archipelago with diverse coral gardens, sea grass beds, mangrove channels, and encounters with green sea turtles and nurse sharks.",
-    "overviewFile": "overview.md",
-    "countryCode": "PA"
-  },
-  {
-    "name": "Coiba National Park",
-    "slug": "coiba-national-park",
-    "region": "South America",
-    "center": [
-      7.5,
-      -81.75
-    ],
-    "bounds": [
-      [
-        7.1,
-        -82.0
-      ],
-      [
-        7.95,
-        -81.3
-      ]
-    ],
-    "description": "Panama's UNESCO marine park dubbed the 'Central American Galápagos' with whale sharks, giant mantas, hammerheads, and pristine Pacific reef systems.",
-    "overviewFile": "overview.md",
-    "countryCode": "PA"
-  },
-  {
-    "name": "Cape Town",
-    "slug": "cape-town",
-    "region": "Africa",
-    "center": [
-      -34.0,
-      18.5
-    ],
-    "bounds": [
-      [
-        -34.4,
-        18.3
-      ],
-      [
-        -33.7,
-        18.9
-      ]
-    ],
-    "description": "Unique kelp forest diving in the Great African Seaforest with over 13,000 endemic marine species, seven-gill cow sharks, and pyjama cat sharks.",
-    "overviewFile": "overview.md",
-    "countryCode": "ZA"
-  },
-  {
-    "name": "Kenya Coast",
-    "slug": "kenya-coast",
-    "region": "Africa",
-    "center": [
-      -4.35,
-      39.55
-    ],
-    "bounds": [
-      [
-        -4.7,
-        39.3
-      ],
-      [
-        -3.3,
-        40.2
-      ]
-    ],
-    "description": "East African coral gardens at Kisite-Mpunguti and Watamu Marine Parks with whale sharks, manta rays, sea turtles, and vibrant Indian Ocean reef life.",
-    "overviewFile": "overview.md",
-    "countryCode": "KE"
-  },
-  {
-    "name": "Ustica",
-    "slug": "ustica",
-    "region": "Europe",
-    "center": [
-      38.71,
-      13.18
-    ],
-    "bounds": [
-      [
-        38.68,
-        13.14
-      ],
-      [
-        38.74,
-        13.22
-      ]
-    ],
-    "description": "Volcanic Mediterranean island and Italy's first marine reserve since 1986, with dramatic lava formations, archaeological sites, and exceptional biodiversity.",
-    "overviewFile": "overview.md",
-    "countryCode": "IT"
-  },
-  {
-    "name": "Port-Cros",
-    "slug": "port-cros",
-    "region": "Europe",
-    "center": [
-      43.0,
-      6.4
-    ],
-    "bounds": [
-      [
-        42.95,
-        6.2
-      ],
-      [
-        43.1,
-        6.55
-      ]
-    ],
-    "description": "Europe's oldest marine reserve on France's Côte d'Azur, birthplace of modern scuba diving with over 50 dive sites and exceptional Mediterranean visibility.",
-    "overviewFile": "overview.md",
-    "countryCode": "FR"
-  },
-  {
-    "name": "Triton Bay",
-    "slug": "triton-bay",
-    "region": "Asia",
-    "center": [
-      -3.85,
-      134.1
-    ],
-    "bounds": [
-      [
-        -4.1,
-        133.7
-      ],
-      [
-        -3.5,
-        134.5
-      ]
-    ],
-    "description": "Remote Indonesian dive frontier with whale sharks feeding on bagan nets, world-class soft corals, endemic flasher wrasse, and pygmy seahorses.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Alor Archipelago",
-    "slug": "alor-archipelago",
-    "region": "Asia",
-    "center": [
-      -8.3,
-      124.35
-    ],
-    "bounds": [
-      [
-        -8.52,
-        123.8
-      ],
-      [
-        -8.0,
-        125.2
-      ]
-    ],
-    "description": "Indonesia's rising macro diving destination rivaling Lembeh Strait, with Rhinopias, rare critters, strong currents, and far fewer crowds.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Ambon",
-    "slug": "ambon",
-    "region": "Asia",
-    "center": [
-      -3.7,
-      128.2
-    ],
-    "bounds": [
-      [
-        -3.8,
-        128.0
-      ],
-      [
-        -3.5,
-        128.4
-      ]
-    ],
-    "description": "Northern Banda Sea muck diving paradise, home to the psychedelic frogfish found nowhere else on Earth, with world-class macro photography opportunities.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Grenada",
-    "slug": "grenada",
-    "region": "Caribbean",
-    "center": [
-      12.12,
-      -61.68
-    ],
-    "bounds": [
-      [
-        11.98,
-        -61.8
-      ],
-      [
-        12.24,
-        -61.58
-      ]
-    ],
-    "description": "Home to the Bianca C — the 'Titanic of the Caribbean' — and the world's first Underwater Sculpture Park, with pristine reefs and volcanic formations.",
-    "overviewFile": "overview.md",
-    "countryCode": "GD"
-  },
-  {
-    "name": "Dominica",
-    "slug": "dominica",
-    "region": "Caribbean",
-    "center": [
-      15.42,
-      -61.35
-    ],
-    "bounds": [
-      [
-        15.2,
-        -61.5
-      ],
-      [
-        15.65,
-        -61.2
-      ]
-    ],
-    "description": "The 'Nature Isle' of the Caribbean with volcanic underwater hot springs, Champagne Reef's bubble dive, and sperm whale encounters year-round.",
-    "overviewFile": "overview.md",
-    "countryCode": "DM"
-  },
-  {
-    "name": "St. Lucia",
-    "slug": "st-lucia",
-    "region": "Caribbean",
-    "center": [
-      13.91,
-      -60.97
-    ],
-    "bounds": [
-      [
-        13.7,
-        -61.08
-      ],
-      [
-        14.12,
-        -60.87
-      ]
-    ],
-    "description": "Dramatic Piton wall dives, the famous Superman's Flight drift dive at Anse Chastanet, with healthy coral gardens beneath volcanic twin peaks.",
-    "overviewFile": "overview.md",
-    "countryCode": "LC"
-  },
-  {
-    "name": "US Virgin Islands",
-    "slug": "us-virgin-islands",
-    "region": "Caribbean",
-    "center": [
-      18.1,
+      32.3,
       -64.8
     ],
     "bounds": [
       [
-        17.6,
-        -65.1
+        32.0,
+        -65.0
       ],
       [
-        18.45,
+        32.5,
         -64.5
       ]
     ],
-    "description": "Buck Island's underwater trail in St. Croix, historic wrecks off St. Thomas, and coral-rich walls across three main islands.",
+    "description": "World-class shipwreck diving, coral reefs, and mysterious blue holes.",
     "overviewFile": "overview.md",
-    "countryCode": "VI"
-  },
-  {
-    "name": "Tobago",
-    "slug": "tobago",
-    "region": "Caribbean",
-    "center": [
-      11.22,
-      -60.67
-    ],
-    "bounds": [
-      [
-        11.1,
-        -60.9
-      ],
-      [
-        11.35,
-        -60.45
-      ]
-    ],
-    "description": "Speyside's world-class drift diving with the world's largest brain coral, giant manta rays, and nutrient-rich waters from South America.",
-    "overviewFile": "overview.md",
-    "countryCode": "TT"
-  },
-  {
-    "name": "Aruba",
-    "slug": "aruba",
-    "region": "Caribbean",
-    "center": [
-      12.51,
-      -69.97
-    ],
-    "bounds": [
-      [
-        12.4,
-        -70.07
-      ],
-      [
-        12.63,
-        -69.87
-      ]
-    ],
-    "description": "The SS Antilla — one of the largest wreck dives in the Caribbean — plus pristine reefs, completing the famous ABC island diving trio.",
-    "overviewFile": "overview.md",
-    "countryCode": "AW"
-  },
-  {
-    "name": "Guadeloupe",
-    "slug": "guadeloupe",
-    "region": "Caribbean",
-    "center": [
-      16.2,
-      -61.55
-    ],
-    "bounds": [
-      [
-        15.85,
-        -61.8
-      ],
-      [
-        16.5,
-        -61.15
-      ]
-    ],
-    "description": "Jacques Cousteau Reserve at Pigeon Island with exceptional marine biodiversity, volcanic reef formations, and France's premier Caribbean diving.",
-    "overviewFile": "overview.md",
-    "countryCode": "GP"
-  },
-  {
-    "name": "Barbados",
-    "slug": "barbados",
-    "region": "Caribbean",
-    "center": [
-      13.18,
-      -59.55
-    ],
-    "bounds": [
-      [
-        13.04,
-        -59.67
-      ],
-      [
-        13.34,
-        -59.42
-      ]
-    ],
-    "description": "Carlisle Bay's six shore-accessible wrecks, sea turtle encounters on every dive, and healthy Atlantic-side reef systems.",
-    "overviewFile": "overview.md",
-    "countryCode": "BB"
-  },
-  {
-    "name": "Sint Eustatius",
-    "slug": "sint-eustatius",
-    "region": "Caribbean",
-    "center": [
-      17.49,
-      -62.98
-    ],
-    "bounds": [
-      [
-        17.44,
-        -63.05
-      ],
-      [
-        17.54,
-        -62.92
-      ]
-    ],
-    "description": "Volcanic diving on the Dutch Caribbean's hidden gem with the Charles L. Brown wreck, pristine marine park, and historic anchor sites.",
-    "overviewFile": "overview.md",
-    "countryCode": "BQ"
-  },
-  {
-    "name": "Dominican Republic",
-    "slug": "dominican-republic",
-    "region": "Caribbean",
-    "center": [
-      18.75,
-      -69.95
-    ],
-    "bounds": [
-      [
-        17.5,
-        -72.0
-      ],
-      [
-        20.0,
-        -68.3
-      ]
-    ],
-    "description": "Silver Bank humpback whale encounters, Catalina Island wall dives, Bayahibe reef systems, and the historic wrecks of La Caleta.",
-    "overviewFile": "overview.md",
-    "countryCode": "DO"
-  },
-  {
-    "name": "Puerto Rico",
-    "slug": "puerto-rico",
-    "region": "Caribbean",
-    "center": [
-      18.22,
-      -66.5
-    ],
-    "bounds": [
-      [
-        17.9,
-        -68.0
-      ],
-      [
-        18.55,
-        -65.2
-      ]
-    ],
-    "description": "Remote Desecheo and Mona Island walls, La Parguera's bioluminescent bay, and diverse Caribbean reef ecosystems across the archipelago.",
-    "overviewFile": "overview.md",
-    "countryCode": "PR"
-  },
-  {
-    "name": "Antigua and Barbuda",
-    "slug": "antigua-and-barbuda",
-    "region": "Caribbean",
-    "center": [
-      17.08,
-      -61.8
-    ],
-    "bounds": [
-      [
-        16.9,
-        -62.0
-      ],
-      [
-        17.75,
-        -61.65
-      ]
-    ],
-    "description": "Pillars of Hercules rock formations, Cades Reef marine park, and historic shipwrecks in the waters of Nelson's Dockyard.",
-    "overviewFile": "overview.md",
-    "countryCode": "AG"
-  },
-  {
-    "name": "St. Vincent and the Grenadines",
-    "slug": "st-vincent-grenadines",
-    "region": "Caribbean",
-    "center": [
-      13.15,
-      -61.2
-    ],
-    "bounds": [
-      [
-        12.5,
-        -61.5
-      ],
-      [
-        13.4,
-        -61.1
-      ]
-    ],
-    "description": "Tobago Cays Marine Park with pristine coral gardens, volcanic black sand sites, drift dives, and rich critter life in uncrowded waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "VC"
-  },
-  {
-    "name": "Jamaica",
-    "slug": "jamaica",
-    "region": "Caribbean",
-    "center": [
-      18.1,
-      -77.3
-    ],
-    "bounds": [
-      [
-        17.7,
-        -78.4
-      ],
-      [
-        18.55,
-        -76.2
-      ]
-    ],
-    "description": "Montego Bay Marine Park, wreck diving off Kingston, vibrant coral walls, and the famous Widowmaker's Cave at Negril.",
-    "overviewFile": "overview.md",
-    "countryCode": "JM"
-  },
-  {
-    "name": "St. Kitts and Nevis",
-    "slug": "st-kitts-and-nevis",
-    "region": "Caribbean",
-    "center": [
-      17.3,
-      -62.73
-    ],
-    "bounds": [
-      [
-        17.08,
-        -62.88
-      ],
-      [
-        17.42,
-        -62.52
-      ]
-    ],
-    "description": "MV River Taw wreck dive, volcanic reef formations, healthy coral gardens, and uncrowded sites in the Lesser Antilles.",
-    "overviewFile": "overview.md",
-    "countryCode": "KN"
-  },
-  {
-    "name": "Martinique",
-    "slug": "martinique",
-    "region": "Caribbean",
-    "center": [
-      14.64,
-      -61.02
-    ],
-    "bounds": [
-      [
-        14.38,
-        -61.23
-      ],
-      [
-        14.88,
-        -60.81
-      ]
-    ],
-    "description": "Diamond Rock's dramatic pinnacle dive, historic St. Pierre wrecks from the 1902 eruption, and French Caribbean coral gardens.",
-    "overviewFile": "overview.md",
-    "countryCode": "MQ"
-  },
-  {
-    "name": "Hawaii - Maui",
-    "slug": "hawaii-maui",
-    "region": "Pacific",
-    "center": [
-      20.8,
-      -156.3
-    ],
-    "bounds": [
-      [
-        20.5,
-        -156.7
-      ],
-      [
-        21.05,
-        -155.95
-      ]
-    ],
-    "description": "World-famous for the Molokini Crater, Maui offers exceptional diving with manta rays, green sea turtles, and seasonal humpback whale encounters in crystal-clear Hawaiian waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Hawaii - Oahu",
-    "slug": "hawaii-oahu",
-    "region": "Pacific",
-    "center": [
-      21.47,
-      -158.0
-    ],
-    "bounds": [
-      [
-        21.25,
-        -158.3
-      ],
-      [
-        21.72,
-        -157.65
-      ]
-    ],
-    "description": "Oahu delivers diverse diving from shipwrecks and reef systems to shark dives and turtle cleaning stations, with easy access from Honolulu and the North Shore.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Hawaii - Kauai",
-    "slug": "hawaii-kauai",
-    "region": "Pacific",
-    "center": [
-      22.05,
-      -159.5
-    ],
-    "bounds": [
-      [
-        21.85,
-        -159.8
-      ],
-      [
-        22.25,
-        -159.28
-      ]
-    ],
-    "description": "The Garden Isle features dramatic lava tube formations, pristine reefs along the Na Pali Coast, and encounters with Hawaiian monk seals and spinner dolphins.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "San Diego - La Jolla",
-    "slug": "san-diego-la-jolla",
-    "region": "North America",
-    "center": [
-      32.85,
-      -117.28
-    ],
-    "bounds": [
-      [
-        32.6,
-        -117.5
-      ],
-      [
-        33.1,
-        -117.1
-      ]
-    ],
-    "description": "Southern California kelp forest diving at its best, featuring La Jolla Cove, Wreck Alley, and abundant marine life including leopard sharks, bat rays, and giant sea bass.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Puget Sound",
-    "slug": "puget-sound",
-    "region": "North America",
-    "center": [
-      47.8,
-      -122.5
-    ],
-    "bounds": [
-      [
-        47.0,
-        -123.2
-      ],
-      [
-        48.8,
-        -122.0
-      ]
-    ],
-    "description": "Cold-water diving paradise in the Pacific Northwest with giant Pacific octopus, wolf eels, six-gill sharks, and colorful anemone gardens in nutrient-rich emerald waters.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "New England",
-    "slug": "new-england",
-    "region": "North America",
-    "center": [
-      41.5,
-      -70.5
-    ],
-    "bounds": [
-      [
-        40.5,
-        -72.0
-      ],
-      [
-        43.0,
-        -69.5
-      ]
-    ],
-    "description": "Historic wreck diving along the Massachusetts, Rhode Island, and Connecticut coasts, with lobster-filled boulder fields, seal encounters, and remnants of centuries of maritime history.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "New Jersey Shore",
-    "slug": "new-jersey",
-    "region": "North America",
-    "center": [
-      39.7,
-      -73.5
-    ],
-    "bounds": [
-      [
-        38.9,
-        -74.5
-      ],
-      [
-        40.5,
-        -73.0
-      ]
-    ],
-    "description": "The Wreck Capital of the Atlantic Coast, featuring hundreds of sunken vessels from WWII U-boat victims to modern artificial reefs, with sand tiger sharks and large pelagics.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "South Florida",
-    "slug": "south-florida",
-    "region": "North America",
-    "center": [
-      26.1,
-      -80.1
-    ],
-    "bounds": [
-      [
-        25.5,
-        -80.5
-      ],
-      [
-        26.7,
-        -79.9
-      ]
-    ],
-    "description": "Year-round warm-water diving from Palm Beach to Miami with drift dives along the Gulf Stream, extensive artificial reef programs, and the Blue Heron Bridge macro paradise.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Flower Garden Banks",
-    "slug": "flower-garden-banks",
-    "region": "North America",
-    "center": [
-      27.9,
-      -93.8
-    ],
-    "bounds": [
-      [
-        27.5,
-        -94.5
-      ],
-      [
-        28.3,
-        -93.0
-      ]
-    ],
-    "description": "The northernmost coral reefs in the continental US, sitting atop salt domes 100 miles offshore Texas in the Gulf of Mexico, with massive coral heads, manta rays, and whale sharks.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "Alaska",
-    "slug": "alaska",
-    "region": "North America",
-    "center": [
-      58.3,
-      -134.4
-    ],
-    "bounds": [
-      [
-        54.0,
-        -170.0
-      ],
-      [
-        63.0,
-        -130.0
-      ]
-    ],
-    "description": "Extreme cold-water diving in pristine wilderness waters with giant Pacific octopus, king crab, sea otters, Steller sea lions, and orca encounters amid dramatic underwater topography.",
-    "overviewFile": "overview.md",
-    "countryCode": "US"
-  },
-  {
-    "name": "British Columbia",
-    "slug": "british-columbia",
-    "region": "North America",
-    "center": [
-      49.3,
-      -123.2
-    ],
-    "bounds": [
-      [
-        48.3,
-        -126.0
-      ],
-      [
-        52.0,
-        -122.0
-      ]
-    ],
-    "description": "Jacques Cousteau called BC waters the best temperate diving in the world. Features giant Pacific octopus, wolf eels, cloud sponge gardens, and the HMCS Saskatchewan artificial reef.",
-    "overviewFile": "overview.md",
-    "countryCode": "CA"
-  },
-  {
-    "name": "Nova Scotia",
-    "slug": "nova-scotia",
-    "region": "North America",
-    "center": [
-      44.6,
-      -63.5
-    ],
-    "bounds": [
-      [
-        43.3,
-        -66.5
-      ],
-      [
-        47.0,
-        -59.5
-      ]
-    ],
-    "description": "Cold Atlantic waters rich in maritime history, with WWII convoy wrecks, the Halifax Explosion aftermath, seal colonies, and the nutrient-rich Bay of Fundy with its extreme tides.",
-    "overviewFile": "overview.md",
-    "countryCode": "CA"
-  },
-  {
-    "name": "Sumbawa",
-    "slug": "sumbawa",
-    "region": "Asia",
-    "center": [
-      -8.25,
-      118.3
-    ],
-    "bounds": [
-      [
-        -8.5,
-        117.4
-      ],
-      [
-        -8.0,
-        119.35
-      ]
-    ],
-    "description": "Indonesia's north Sumbawa coast with whale shark encounters in Saleh Bay, dramatic walls around Moyo Island marine park, volcanic geothermal vents at Sangeang Island, and sheltered muck diving at Satonda's sunken caldera.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Banda Sea",
-    "slug": "banda-sea",
-    "region": "Asia",
-    "center": [
-      -4.57,
-      129.87
-    ],
-    "bounds": [
-      [
-        -5.65,
-        129.6
-      ],
-      [
-        -4.35,
-        130.4
-      ]
-    ],
-    "description": "Historic spice island archipelago with the celebrated Lava Flow coral recovery site, hammerhead sharks at Jackpot pinnacle, Mandarin fish at Maulana, and the sea snake-rich volcanic walls of remote Manuk Island.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Halmahera",
-    "slug": "halmahera",
-    "region": "Asia",
-    "center": [
-      1.0,
-      128.0
-    ],
-    "bounds": [
-      [
-        -0.5,
-        127.0
-      ],
-      [
-        2.5,
-        129.0
-      ]
-    ],
-    "description": "North Maluku's unexplored diving frontier with WWII wrecks, vibrant soft coral walls, whale shark encounters, and the unique marine biodiversity of the Halmahera Sea.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
-  },
-  {
-    "name": "Sangalaki (Derawan Islands)",
-    "slug": "sangalaki",
-    "region": "Asia",
-    "center": [
-      2.19,
-      118.44
-    ],
-    "bounds": [
-      [
-        2.03,
-        118.18
-      ],
-      [
-        2.38,
-        118.68
-      ]
-    ],
-    "description": "Indonesia's manta ray capital with resident mantas at Sangalaki, the world's only accessible saltwater jellyfish lake at Kakaban, big fish drift dives at Maratua atoll, and macro-rich muck diving at Derawan.",
-    "overviewFile": "overview.md",
-    "countryCode": "ID"
+    "countryCode": "BM"
   }
 ]

--- a/scripts/batch_collect_dive_sites_osm.py
+++ b/scripts/batch_collect_dive_sites_osm.py
@@ -67,7 +67,7 @@ def load_destinations():
     """Load destinations from destinations.json"""
     try:
         with open('destinations.json', 'r', encoding='utf-8') as f:
-            destinations = json.load(f)
+            destinations = [d for d in json.load(f) if not d.get("isGroup")]
         return destinations
     except Exception as e:
         print(f"Error loading destinations.json: {e}")

--- a/scripts/check_gps_quality.py
+++ b/scripts/check_gps_quality.py
@@ -339,7 +339,7 @@ def print_report(results, summary_mode=False):
 
 def main():
     with open(PROJECT_ROOT / "destinations.json") as f:
-        all_dests = {d["slug"]: d for d in json.load(f)}
+        all_dests = {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
     # Parse arguments
     args = sys.argv[1:]

--- a/scripts/fetch_external_sources.py
+++ b/scripts/fetch_external_sources.py
@@ -62,7 +62,7 @@ def rate_limit(source, min_interval=1.0):
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def get_gap_destinations(min_sites=5):

--- a/scripts/fetch_gap_sites.py
+++ b/scripts/fetch_gap_sites.py
@@ -387,7 +387,7 @@ def load_destinations():
     """Load destination definitions."""
     with open(DESTINATIONS_FILE) as f:
         dests = json.load(f)
-    return {d["slug"]: d for d in dests}
+    return {d["slug"]: d for d in dests if not d.get("isGroup")}
 
 
 def get_existing_site_names(slug):

--- a/scripts/fill_caribbean.py
+++ b/scripts/fill_caribbean.py
@@ -231,7 +231,7 @@ CURATED_SITES = {
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def in_bounds(lat, lon, bounds):

--- a/scripts/fill_new_destinations.py
+++ b/scripts/fill_new_destinations.py
@@ -164,7 +164,7 @@ CURATED_SITES = {
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def in_bounds(lat, lon, bounds):

--- a/scripts/fill_remaining_gaps.py
+++ b/scripts/fill_remaining_gaps.py
@@ -256,7 +256,7 @@ CURATED_SITES = {
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def in_bounds(lat, lon, bounds):

--- a/scripts/gather_all_dive_sites.py
+++ b/scripts/gather_all_dive_sites.py
@@ -13,7 +13,7 @@ def load_destinations():
     """Load destinations from destinations.json"""
     try:
         with open('../destinations.json', 'r', encoding='utf-8') as f:
-            return json.load(f)
+            return [d for d in json.load(f) if not d.get("isGroup")]
     except FileNotFoundError:
         print("Error: destinations.json not found. Make sure you're running from the scripts directory.")
         sys.exit(1)

--- a/scripts/gather_osm_all.py
+++ b/scripts/gather_osm_all.py
@@ -189,6 +189,8 @@ def main():
 
     results_summary = []
     for dest in destinations:
+        if dest.get("isGroup"):
+            continue
         slug = dest["slug"]
         if slug in SKIP_SLUGS:
             print(f"Skipping {slug} (already has data)")

--- a/scripts/gather_osm_extended.py
+++ b/scripts/gather_osm_extended.py
@@ -62,7 +62,7 @@ BUSINESS_TAGS = {"shop", "tourism", "amenity", "office"}
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def build_overpass_query(bounds, wrecks_only=False):

--- a/scripts/generate_overviews.py
+++ b/scripts/generate_overviews.py
@@ -127,7 +127,7 @@ def generate_overview(dest, stats, region_data):
         site_types.append(f"**Wreck Diving**: {stats['wrecks']} wreck sites ranging from historic vessels to purpose-sunk artificial reefs")
 
     # Always include these based on region
-    if region in ("Caribbean", "Asia", "Pacific", "Middle East", "Africa", "Oceania"):
+    if region in ("Caribbean", "Asia", "Pacific", "Middle East", "Africa", "Oceania", "Central America", "South America"):
         site_types.append("**Reef Diving**: Healthy coral reef systems supporting diverse marine ecosystems")
     if region in ("Europe", "North America", "Arctic"):
         if stats["wrecks"] == 0:
@@ -177,7 +177,7 @@ addedBy: osm_import
 
 - **Water Conditions**: Water temperatures range from {region_data['water_temp']} with visibility of {region_data['visibility']}. Currents are generally {region_data['current'].lower()}.
 - **Marine Biodiversity**: The waters support diverse marine ecosystems including {marine_species}.
-- **Conservation**: {'Marine protected areas help preserve the reef ecosystems and regulate diving activities.' if region in ('Caribbean', 'Pacific', 'Asia', 'Oceania', 'Middle East') else 'Local conservation efforts help protect marine habitats and ensure sustainable diving practices.'}
+- **Conservation**: {'Marine protected areas help preserve the reef ecosystems and regulate diving activities.' if region in ('Caribbean', 'Pacific', 'Asia', 'Oceania', 'Middle East', 'Central America', 'South America') else 'Local conservation efforts help protect marine habitats and ensure sustainable diving practices.'}
 
 ## Additional Information
 
@@ -213,6 +213,8 @@ def main():
 
     generated = 0
     for dest in destinations:
+        if dest.get("isGroup"):
+            continue
         slug = dest["slug"]
         if slug in skip_slugs:
             continue

--- a/scripts/generate_sites.py
+++ b/scripts/generate_sites.py
@@ -56,6 +56,21 @@ REGION_DATA = {
         "hazards": ["cold water", "surge", "limited visibility", "boat traffic", "currents"],
         "current": "Variable, can be strong",
     },
+    "Central America": {
+        "water_temp": "26-29°C (79-84°F)",
+        "visibility": "15-35 meters (50-115 feet)",
+        "best_season": "December to April (dry season)",
+        "year_round": True,
+        "typical_marine_life": [
+            "sea turtles (green, hawksbill)", "whale sharks", "reef sharks",
+            "nurse sharks", "eagle rays", "hammerhead sharks", "manta rays",
+            "parrotfish", "angelfish", "barracuda", "moray eels",
+            "brain corals", "elkhorn corals", "sea fans", "barrel sponges"
+        ],
+        "wreck_marine_life": ["groupers", "snappers", "soldierfish", "glassy sweepers", "coral growth", "sponge encrustation"],
+        "hazards": ["strong currents", "boat traffic", "fire coral", "thermoclines", "remote locations"],
+        "current": "Moderate to strong",
+    },
     "South America": {
         "water_temp": "15-26°C (59-79°F)",
         "visibility": "10-25 meters (30-80 feet)",
@@ -570,7 +585,7 @@ def main():
     with open(project_root / "destinations.json", "r", encoding="utf-8") as f:
         destinations = json.load(f)
 
-    dest_by_slug = {d["slug"]: d for d in destinations}
+    dest_by_slug = {d["slug"]: d for d in destinations if not d.get("isGroup")}
 
     # Skip destinations that already have hand-curated content
     skip_slugs = {"bonaire", "curacao"}

--- a/scripts/scrape_padi.py
+++ b/scripts/scrape_padi.py
@@ -324,7 +324,7 @@ def main():
 
 def load_destinations():
     with open(DESTINATIONS_FILE) as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 if __name__ == "__main__":

--- a/scripts/validate_coordinates.py
+++ b/scripts/validate_coordinates.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 def load_destinations():
     project_root = Path(__file__).parent.parent
     with open(project_root / "destinations.json") as f:
-        return {d["slug"]: d for d in json.load(f)}
+        return {d["slug"]: d for d in json.load(f) if not d.get("isGroup")}
 
 
 def haversine_distance(lat1, lon1, lat2, lon2):


### PR DESCRIPTION
## Summary
This PR adds filtering logic across multiple data processing scripts to exclude group destinations (marked with `isGroup: true`) from being processed as individual dive sites. This prevents group/parent destinations from being treated as actual dive locations during data collection and validation.

## Key Changes
- **destinations.json**: Added "Central America" region definition and expanded destination data (+1781/-1407 lines)
- **Multiple scripts updated with `isGroup` filtering**:
  - `fill_caribbean.py`
  - `fill_new_destinations.py`
  - `fill_remaining_gaps.py`
  - `gather_osm_all.py`
  - `gather_osm_extended.py`
  - `scrape_padi.py`
  - `validate_coordinates.py`

All scripts now filter destinations using `if not d.get("isGroup")` when loading destination data, ensuring that only actual dive site destinations are processed.

- **generate_overviews.py**: Minor adjustment to overview generation logic
- **Other scripts**: Code cleanup and consistency improvements in destination loading functions

## Implementation Details
The filtering is applied consistently across all destination loading functions using a simple conditional check: `if not d.get("isGroup")`. This allows the data structure to support hierarchical destination organization while preventing group entries from being processed as individual dive sites during data collection, validation, and report generation workflows.

https://claude.ai/code/session_011iPZLguhQqv1G4JykkoJfm