### PR TITLE
Update dive site: RMS Rhone

### DIFF
--- a/divesites/british-virgin-islands/index.json
+++ b/divesites/british-virgin-islands/index.json
@@ -1,15 +1,12 @@
 [
   {
     "name": "RMS Rhone",
+    "lat": "18.3733",
+    "lng": "-64.6269",
     "filename": "rms-rhone.md",
-    "lat": 18.3733,
-    "lng": -64.6269,
+    "addedBy": "osm_import",
     "difficulty": "Intermediate",
-    "maxDepth": 26,
-    "entryType": "boat",
-    "siteType": "wreck",
-    "ref": "",
-    "osmId": null
+    "maxDepth": "26"
   },
   {
     "name": "The Indians",

--- a/divesites/british-virgin-islands/rms-rhone.md
+++ b/divesites/british-virgin-islands/rms-rhone.md
@@ -1,15 +1,14 @@
 ---
-name: RMS Rhone
+name: "RMS Rhone"
 lat: 18.3733
 lng: -64.6269
-difficulty: Intermediate
+difficulty: "Intermediate"
 maxDepth: 26
-entryType: boat
-siteType: wreck
-ref: null
-osmId: null
-addedBy: osm_import
+entryType: "boat"
+siteType: "wreck"
+addedBy: "osm_import"
 ---
+
 
 # RMS Rhone
 
@@ -62,4 +61,4 @@ The RMS Rhone is among the most photographed wrecks in the world. The stern sect
 - The wreck is accessible to charter yachts — many BVI bareboat itineraries include a Rhone stop
 
 ---
-*Sources: [Dive BVI - Dive Sites](https://divebvi.com/dive-sites/), [BVI Dive Map](https://bvi-dive-map.com/), [Bluewater Dive Travel - British Virgin Islands Diving](https://www.bluewaterdivetravel.com/destination/british-virgin-islands-diving), [Dive The World - British Virgin Islands](https://www.dive-the-world.com/diving-sites-british-virgin-islands.php), [BVI Scuba - Diving Info](https://bviscuba.org/diving-info/). Last updated 2026-04-04.*
+*Sources: Test Edit, [Dive BVI - Dive Sites](https://divebvi.com/dive-sites/), [BVI Dive Map](https://bvi-dive-map.com/), [Bluewater Dive Travel - British Virgin Islands Diving](https://www.bluewaterdivetravel.com/destination/british-virgin-islands-diving), [Dive The World - British Virgin Islands](https://www.dive-the-world.com/diving-sites-british-virgin-islands.php), [BVI Scuba - Diving Info](https://bviscuba.org/diving-info/). Last updated 2026-04-04.*


### PR DESCRIPTION
## Updates dive site: RMS Rhone

**Destination:** british-virgin-islands
**Contributor:** @jbunderwater
**Action:** Update existing site

### Changes
- updates dive site information for RMS Rhone
- Updated markdown file: `divesites/british-virgin-islands/rms-rhone.md`
- Updated metadata in `divesites/british-virgin-islands/index.json`

### Site Details
- **Name:** RMS Rhone
- **Difficulty:** Intermediate
- **Max Depth:** 26 feet
- **Coordinates:** 18.3733, -64.6269

### Checklist
- [x] Follows the established markdown format
- [x] Includes all required frontmatter fields
- [x] Provides helpful description and tips
- [x] Coordinates are accurate
- [x] Difficulty and depth information is correct

---
*This PR was created via the Dive Vibe community contribution system.*