### PR TITLE
Add Crystal River & Rainbow River and Venice Beach destinations

### DIFF
--- a/data/osm_clean/crystal-river.json
+++ b/data/osm_clean/crystal-river.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Three Sisters Springs",
+    "lat": 28.888725,
+    "lon": -82.589191,
+    "depth": 3,
+    "site_type": "cave",
+    "entry_type": "boat",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A 57-acre unit of Crystal River National Wildlife Refuge on Kings Bay, comprising three linked spring pools (Little Sister, Big Sister, Pretty Sister). Water holds a stable ~73F year-round. Documented as the only enclosed water body in the US open to the public for entering the water with wintering manatees, present roughly Nov 15-Mar 31. No direct road/shore water access - reached by kayak, paddle-craft, or swimming from an outside launch (a land-based boardwalk offers viewing only, no water entry from it). Scuba diving is permitted only April 1-Nov 14; snorkeling is year-round but subject to sanctuary boundary closures. Depth not stated precisely by sources - estimated shallow based on descriptions of wading/snorkeling pools.", "validation_source": "en.wikipedia.org,fws.gov"}
+  },
+  {
+    "name": "King Spring",
+    "lat": 28.881719,
+    "lon": -82.595050,
+    "depth": 18,
+    "site_type": "cave",
+    "entry_type": "boat",
+    "difficulty": "Intermediate",
+    "tags": {"source": "curated_research", "notes": "The largest spring in Kings Bay and the original spring whose winter manatee concentrations prompted the 1983 creation of Crystal River National Wildlife Refuge. Boat/kayak access only (via boat landings or paddle from Crystal River launch points, south side of Banana Island). DEPTH CONFLICT: sources disagree significantly - one gives ~15ft at the vent, another lists 51-60ft, another describes a ~30ft open basin with an associated cave descending another ~60ft; a further source's ~65ft figure may conflate King Spring with the separately-monitored Tarpon Hole spring nearby (naming/identity ambiguity between these two sites was not resolved by research - treat as a known open question). Scuba is allowed year-round outside marked manatee 'keyhole' sanctuary zones, with access most restricted Nov 15-Mar 31. Has an associated cavern/cave system requiring cave/cavern certification beyond the open vent.", "validation_source": "flsprings.com,divebuddy.com,dtmag.com,fws.gov"}
+  },
+  {
+    "name": "Idiot's Delight",
+    "lat": 28.88795184,
+    "lon": -82.58945355,
+    "depth": 6,
+    "site_type": "cave",
+    "entry_type": "boat",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A cluster of narrow spring vents/shafts (at least three numbered vents, the largest ~5ft diameter) at the confluence of a canal and the Three Sisters Springs run. Part of the Kings Bay SpringsWatch monitoring network. Kayak/paddle or swim-in access only from the adjoining canal/spring run; no dedicated shore parking. Sometimes closed as a roped manatee sanctuary during the winter season (Nov-Mar) - verify current access status before visiting, as closures are periodic rather than fixed.", "validation_source": "floridaspringlife.com,floridacaves.com"}
+  },
+  {
+    "name": "Hunter Springs Park",
+    "lat": 28.89564,
+    "lon": -82.59203,
+    "depth": 3,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A public park (104 NE 1st Ave, Crystal River) at the mouth of Hunter Spring Run, historically known as 'Legion Beach'/American Legion Spring before being renamed. The most accessible independent shore/kayak put-in on Kings Bay, with a small beach, roped swimming area, kayak/canoe launch, and boardwalk. Clear water over a white sand/partial grass bottom. Manatee encounters possible but not guaranteed, more likely Nov-Mar. Depth not stated precisely by sources - estimated shallow based on descriptions of a roped shallow swim area.", "validation_source": "floridarambler.com,tripshock.com"}
+  },
+  {
+    "name": "Jurassic Spring",
+    "lat": 28.89507562,
+    "lon": -82.58991977,
+    "depth": 5,
+    "site_type": "cave",
+    "entry_type": "boat",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A second-magnitude spring on Hunter Spring Run, reached via kayak/paddle/swim from Hunter Springs Park (small cove roughly 800ft east of Hunter Spring). One of the Kings Bay SpringsWatch monitoring stations. Depth reported to vary with tide (roughly 15-20ft/4.5-6m). Manatees reported to frequent it seasonally for warmth (winter months); the site may close periodically during cold snaps or heavy manatee presence. Name reportedly ties to mammoth fossil finds per secondary sources, not independently verified against a primary geological record.", "validation_source": "floridaspringlife.com,springsinflorida.com"}
+  },
+  {
+    "name": "Rainbow Springs Headspring",
+    "lat": 29.1026,
+    "lon": -82.4370,
+    "depth": 4,
+    "site_type": "cave",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "The first-magnitude headspring (reported flow ~410-600 million gal/day depending on source) of the Rainbow River, emerging from dozens of vents into a wide swimmable basin within Rainbow Springs State Park (19158 SW 81st Place Road, Dunnellon). Water holds ~72F year-round with commonly reported visibility of 20-40+ ft (reduced after heavy rain per one source). Historically called 'Blue Spring' until a 1930s tourism rebrand (submarine boat tours, 1950s mermaid shows); state-acquired in 1990. This is explicitly a swimming/snorkeling site, NOT a scuba destination - the park's own activity guidance centers on swimming/snorkeling/canoeing/kayaking, and snorkeling is permitted only within a buoyed swim area. Depth figure is from a single aggregator source, not independently cross-confirmed - treat as approximate.", "validation_source": "en.wikipedia.org,floridastateparks.org"}
+  },
+  {
+    "name": "K.P. Hole County Park",
+    "lat": 29.08678,
+    "lon": -82.43029,
+    "depth": 6,
+    "site_type": "drift",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "The primary public access point for the Rainbow River downstream of Rainbow Springs State Park (9435 SW 190th Avenue Rd, Dunnellon), with a boat ramp and kayak/canoe/paddleboard launch. Water ~72F with commonly cited visibility of 100+ft. Sources describe the river as a drift/snorkel experience rather than a fixed dive site - shallow channels (roughly 5-8ft) connect to deeper holes (up to ~20-27ft depending on source) that can be scuba-dived; divers commonly shuttle upstream and drift back down. This is a snorkel/drift-dive river, not a technical scuba destination. Tubing (seasonal, Apr-Sep), alcohol, and disposable containers are regulated as part of an Outstanding Florida Water/Aquatic Preserve.", "validation_source": "visitfloridasprings.org,scubaboard.com"}
+  }
+]

--- a/data/osm_clean/venice-beach.json
+++ b/data/osm_clean/venice-beach.json
@@ -1,0 +1,102 @@
+[
+  {
+    "name": "Caspersen Beach",
+    "lat": 27.057233,
+    "lon": -82.442700,
+    "depth": 2,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A largely undeveloped, ~2.5-mile county park beach (4100 Harbor Dr S, Venice) south of downtown Venice, widely cited across independent sources as the single best free shark-tooth beach in the area. Rocky, less-trafficked shoreline with thick black-sand/shell lines that concentrate fossils; best hunting is in the surf zone and between the beach and first sandbar, especially at low tide and after storms. Reported finds (well-corroborated across sources): sand, lemon, mako, bull, and whitetip shark teeth, plus occasional megalodon teeth.", "validation_source": "mustdo.com,visitflorida.com,fossilguy.com,sarasota.fish"}
+  },
+  {
+    "name": "Brohard Beach (North Brohard Paw Park)",
+    "lat": 27.0745,
+    "lon": -82.4503,
+    "depth": 1,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "COORDINATE FLAG: interpolated from the street address (1400 Harbor Dr S), not independently geocoded - treat as approximate. Venice's only dog-friendly beach, immediately north of the Venice Fishing Pier area. Shark teeth wash up mixed with shells, more easily found after storms or at low tide. One source explicitly notes unpredictable rip currents here (distinct from calmer conditions at Caspersen) - worth noting for less experienced waders/snorkelers.", "validation_source": "venicegov.com,locallifehomes.com"}
+  },
+  {
+    "name": "South Brohard Park",
+    "lat": 27.068,
+    "lon": -82.448,
+    "depth": 4.5,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Intermediate",
+    "tags": {"source": "curated_research", "notes": "COORDINATE FLAG: approximate - source addresses for this park conflicted (1900 vs 2782 Harbor Dr S), not independently geocoded. A day-use park (separate from the dog-friendly North Brohard/Paw Park) offering shore access to a placed limestone-block artificial reef (~15ft deep, ~50yd past the sandbar heading 250 degrees from the south boardwalk) and a coquina reef, plus a black-sand fossil zone further out (~250yd, heading 300 degrees). A detailed first-hand trip report rated this site not recommended for beginners, given long swims with heavy collection bags. Reported finds: mammal fossils, shark teeth, mammoth bone/tusk fragments, horse/llama teeth, alligator and turtle fossils - single trip-report source for the specific species list.", "validation_source": "scubaboard.com"}
+  },
+  {
+    "name": "Venice Fishing Pier (Sharky's Beach)",
+    "lat": 27.073216,
+    "lon": -82.449724,
+    "depth": 5,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "The area around the Venice Fishing Pier and adjacent Sharky's restaurant/pavilion (1600 Harbor Dr S), split into north and south sections by divers. Broken shell and black sand bottom reported at depth (~15-18ft, roughly 150yd offshore past a shallow sandbar). ACCESS NOTE: divers must stay more than 100 yards from the pier itself when scuba diving, per a local diver's account of Sheriff's Department enforcement - verify current local rules before diving here.", "validation_source": "scubaboard.com"}
+  },
+  {
+    "name": "Service Club Park",
+    "lat": 27.076,
+    "lon": -82.451,
+    "depth": 4.5,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "COORDINATE FLAG: interpolated from the street address (1190-1220 Harbor Dr S), not independently geocoded - treat as approximate. A community-built park (developed by local service clubs) with a boardwalk to the beach and paved parking. Multiple independent sources specifically cite this site for megalodon tooth discoveries on the sandy Gulf floor just offshore (~15ft deep, ~100yd out, heading 250 degrees from the boardwalk steps), with a 'culvert' artificial reef roughly 200yd farther out. Limited/small parking noted as a drawback.", "validation_source": "venicegov.com,scubaboard.com"}
+  },
+  {
+    "name": "Venice Beach (Main/North Public Beach)",
+    "lat": 27.09758,
+    "lon": -82.46225,
+    "depth": 5.8,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "Venice's main public beach near the historic downtown/lifeguard-tower area, north of the pier. DEPTH CONFLICT: an official PADI dive-site listing states a maximum depth of only 6ft/1.8m, while independent diver reviews describe a productive zone ~100yd offshore from the lifeguard tower at 16-21ft with a stated site maximum of 19ft/5.8m - both figures reported here rather than resolved. Widely reported as a productive shore-snorkel/dive fossil site with rocky reef structures and sand dollars offshore; one reviewer reported finding upwards of 60 teeth in a one-hour dive, some over 4 inches - single-source claim, not independently corroborated. Visibility reported poor and choppy-condition-dependent (roughly 5-15ft typical, occasionally 1-2ft). Boat traffic is a specifically noted hazard - use of a dive flag/buoy is advised.", "validation_source": "padi.com,zentacle.com"}
+  },
+  {
+    "name": "Manasota Beach",
+    "lat": 26.94028,
+    "lon": -82.36389,
+    "depth": 1,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A Sarasota County park beach on Manasota Key (8570 Manasota Key Rd, Englewood), described as 'the gateway to the Shark Tooth Capital of the World.' Distinctive, well-corroborated detail: shark teeth are visibly embedded in the concrete of the beach's boardwalk/walkway itself, in addition to being found in the sand and shallow water via wading (knee to waist deep).", "validation_source": "fossilguy.com,locallifehomes.com"}
+  },
+  {
+    "name": "Blind Pass Beach",
+    "lat": 26.958539,
+    "lon": -82.382810,
+    "depth": 1.5,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "A quieter, less-developed county beach park (6725 Manasota Key Rd, Englewood) at the tidal cut ('pass') between Manasota Key and Palm Island. Tidal action through the pass is described as consistently depositing shells, sand dollars, and shark teeth along the shoreline; multiple sources note clearer, emerald-tinted water than average for the area.", "validation_source": "visitflorida.com,visitsarasota.com"}
+  },
+  {
+    "name": "Nokomis Beach",
+    "lat": 27.124,
+    "lon": -82.470,
+    "depth": 1,
+    "site_type": "beach",
+    "entry_type": "shore",
+    "difficulty": "Beginner",
+    "tags": {"source": "curated_research", "notes": "COORDINATE FLAG: approximate (Nokomis Beach Pavilion area) - not independently geocoded. A public beach on the southern portion of Casey Key, north of Venice proper. Multiple sources explicitly caveat that teeth here are smaller and less concentrated than at Venice-area beaches like Caspersen, though the less-crowded northern stretch (a short walk from the main access point) is reported as more productive than the immediate access area.", "validation_source": "locallifehomes.com,floridawanderers.com"}
+  },
+  {
+    "name": "The Boneyard",
+    "lat": 27.085,
+    "lon": -82.468,
+    "depth": 8,
+    "site_type": "muck",
+    "entry_type": "boat",
+    "difficulty": "Intermediate",
+    "tags": {"source": "curated_research", "notes": "COORDINATE FLAG: approximate only - based on one hobbyist-shared GPS post on a dive forum (charter operators reportedly keep exact coordinates private); treat as unverified/approximate. An ancient, submerged riverbed roughly half a mile to a mile offshore from the Venice/Alhambra area, running roughly parallel to the coast. Per Richard C. Hulbert Jr. (Florida Museum of Natural History), sediments here were deposited 3-10 million years ago when Florida's coastline extended much farther into the Gulf. The bone bed contains megalodon teeth (reported up to 7 inches) plus remains attributed to saber-toothed cats, Columbian mammoths, 'bear dogs,' American lions, gomphotheres, camels, and horses - the primary target for local dive charters seeking larger, better-preserved teeth than typically survive to the beach. Depth reported 25-35ft across sources, most consistently ~25-30ft. Soft-sediment anchor-dive site with little to no current per charter descriptions (not a true current-driven drift site).", "validation_source": "floridatrend.com,scubaboard.com"}
+  }
+]

--- a/destinations.json
+++ b/destinations.json
@@ -3957,5 +3957,51 @@
     "countryCode": "US",
     "parentSlug": "us",
     "overviewFile": "overview.md"
+  },
+  {
+    "name": "Crystal River & Rainbow River",
+    "slug": "crystal-river",
+    "region": "North America",
+    "center": [
+      28.98,
+      -82.51
+    ],
+    "bounds": [
+      [
+        28.8,
+        -82.65
+      ],
+      [
+        29.2,
+        -82.35
+      ]
+    ],
+    "description": "Spring-fed snorkeling and diving on Florida's Nature Coast, centered on Crystal River / Kings Bay — the only place in the US where the public may legally enter the water with wild manatees in season (Nov-Mar) — plus the exceptionally clear Rainbow River near Dunnellon.",
+    "countryCode": "US",
+    "parentSlug": "us",
+    "overviewFile": "overview.md"
+  },
+  {
+    "name": "Venice Beach",
+    "slug": "venice-beach",
+    "region": "North America",
+    "center": [
+      27.02,
+      -82.44
+    ],
+    "bounds": [
+      [
+        26.85,
+        -82.55
+      ],
+      [
+        27.2,
+        -82.3
+      ]
+    ],
+    "description": "The self-proclaimed 'Shark Tooth Capital of the World' on Florida's Sarasota County Gulf Coast, where fossilized shark teeth (including megalodon) erode out of the offshore Peace River Formation and wash up on beaches or concentrate in an ancient submerged riverbed reachable by boat.",
+    "countryCode": "US",
+    "parentSlug": "us",
+    "overviewFile": "overview.md"
   }
 ]

--- a/divesites/crystal-river/hunter-springs-park.md
+++ b/divesites/crystal-river/hunter-springs-park.md
@@ -1,0 +1,31 @@
+---
+name: Hunter Springs Park
+lat: 28.89564
+lng: -82.59203
+difficulty: Beginner
+maxDepth: 3
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Hunter Springs Park
+
+Hunter Springs Park is a beach dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+A public park at the mouth of Hunter Spring Run, historically known as 'Legion Beach' or American Legion Spring before being renamed. It's the most accessible independent shore or kayak put-in on Kings Bay, with a small beach, roped swimming area, kayak/canoe launch, and boardwalk. The water is clear over a white sand and partial grass bottom. Manatee encounters are possible here but not guaranteed — they're more likely in the colder months, roughly November through March. Depth isn't stated precisely by any source found — the figure here is a rough estimate based on descriptions of a shallow, roped swim area.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 3 meters
+
+---
+*Sources: [Florida Rambler — Crystal River Manatees](https://www.floridarambler.com/kayaking-in-florida/crystal-river-manatees/), [TripShock — Hunter Springs Park](https://www.tripshock.com/destination/fl/crystal-river/landmarks/hunter-springs-park/). Last updated 2026-08-08.*

--- a/divesites/crystal-river/idiots-delight.md
+++ b/divesites/crystal-river/idiots-delight.md
@@ -1,0 +1,31 @@
+---
+name: Idiot's Delight
+lat: 28.88795184
+lng: -82.58945355
+difficulty: Beginner
+maxDepth: 6
+entryType: boat
+siteType: cave
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Idiot's Delight
+
+Idiot's Delight is a cave dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+A cluster of narrow spring vents — at least three numbered shafts, the largest around 5 ft in diameter — at the confluence of a canal and the Three Sisters Springs run. It's one of the sites in the Kings Bay SpringsWatch monitoring network. Reachable only by kayak, paddle-craft, or swimming in from the adjoining canal or spring run; there's no dedicated shore parking. The site is sometimes closed as a roped manatee sanctuary during winter — access is periodic rather than fixed, so check current status before visiting.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Boat dive
+- **Site Type**: Cave/cavern
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 6 meters
+
+---
+*Sources: [Florida Spring Life — Idiot's Delight Spring](https://www.floridaspringlife.com/florida-springs/locate/idiots-delight-spring/154/), [Florida Caves — Crystal River Springs](http://www.floridacaves.com/crystalriver.htm). Last updated 2026-08-08.*

--- a/divesites/crystal-river/index.json
+++ b/divesites/crystal-river/index.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "Three Sisters Springs",
+    "filename": "three-sisters-springs.md",
+    "lat": 28.888725,
+    "lng": -82.589191,
+    "difficulty": "Beginner",
+    "maxDepth": 3,
+    "entryType": "boat",
+    "siteType": "cave",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "King Spring",
+    "filename": "king-spring.md",
+    "lat": 28.881719,
+    "lng": -82.59505,
+    "difficulty": "Intermediate",
+    "maxDepth": 18,
+    "entryType": "boat",
+    "siteType": "cave",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Idiot's Delight",
+    "filename": "idiots-delight.md",
+    "lat": 28.88795184,
+    "lng": -82.58945355,
+    "difficulty": "Beginner",
+    "maxDepth": 6,
+    "entryType": "boat",
+    "siteType": "cave",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Hunter Springs Park",
+    "filename": "hunter-springs-park.md",
+    "lat": 28.89564,
+    "lng": -82.59203,
+    "difficulty": "Beginner",
+    "maxDepth": 3,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Jurassic Spring",
+    "filename": "jurassic-spring.md",
+    "lat": 28.89507562,
+    "lng": -82.58991977,
+    "difficulty": "Beginner",
+    "maxDepth": 5,
+    "entryType": "boat",
+    "siteType": "cave",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Rainbow Springs Headspring",
+    "filename": "rainbow-springs-headspring.md",
+    "lat": 29.1026,
+    "lng": -82.437,
+    "difficulty": "Beginner",
+    "maxDepth": 4,
+    "entryType": "shore",
+    "siteType": "cave",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "K.P. Hole County Park",
+    "filename": "kp-hole-county-park.md",
+    "lat": 29.08678,
+    "lng": -82.43029,
+    "difficulty": "Beginner",
+    "maxDepth": 6,
+    "entryType": "shore",
+    "siteType": "drift",
+    "ref": "",
+    "osmId": null
+  }
+]

--- a/divesites/crystal-river/jurassic-spring.md
+++ b/divesites/crystal-river/jurassic-spring.md
@@ -1,0 +1,31 @@
+---
+name: Jurassic Spring
+lat: 28.89507562
+lng: -82.58991977
+difficulty: Beginner
+maxDepth: 5
+entryType: boat
+siteType: cave
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Jurassic Spring
+
+Jurassic Spring is a cave dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+A second-magnitude spring on Hunter Spring Run, reached by kayak, paddle-craft, or swimming from Hunter Springs Park via a small cove roughly 800 ft east of Hunter Spring. It's one of the Kings Bay SpringsWatch monitoring stations. Depth is reported to vary with tide, roughly 15–20 ft. Manatees are reported to frequent it seasonally for warmth during winter months, and the site may close periodically during cold snaps or heavy manatee presence. The name reportedly comes from mammoth fossil finds according to secondary sources, though that wasn't independently verified against a primary geological record.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Boat dive
+- **Site Type**: Cave/cavern
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 5 meters
+
+---
+*Sources: [Florida Spring Life — Jurassic Spring](https://www.floridaspringlife.com/florida-springs/locate/jurassic-spring/155/), [Springs In Florida — Jurassic Spring](https://springsinflorida.com/springs/jurassic-spring/). Last updated 2026-08-08.*

--- a/divesites/crystal-river/king-spring.md
+++ b/divesites/crystal-river/king-spring.md
@@ -1,0 +1,31 @@
+---
+name: King Spring
+lat: 28.881719
+lng: -82.59505
+difficulty: Intermediate
+maxDepth: 18
+entryType: boat
+siteType: cave
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## King Spring
+
+King Spring is a cave dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+The largest spring in Kings Bay, and the one whose winter manatee concentrations prompted the 1983 creation of the Crystal River National Wildlife Refuge. Boat or kayak access only, via boat landings or a paddle from Crystal River launch points on the south side of Banana Island. **Depth conflict**: sources disagree significantly here — one gives roughly 15 ft at the vent itself, another lists 51–60 ft, a third describes a ~30 ft open basin with an associated cave descending another 60 ft, and a fourth's ~65 ft figure may actually describe the separately-monitored Tarpon Hole spring nearby rather than King Spring itself — the two names may or may not refer to the same feature, and that wasn't resolved by this research. Scuba diving is allowed year-round outside marked manatee 'keyhole' sanctuary zones, with access most restricted November 15–March 31. An associated cavern/cave system extends beyond the open vent and requires cave/cavern certification.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Boat dive
+- **Site Type**: Cave/cavern
+- **Difficulty Level**: Intermediate
+- **Maximum Depth**: 18 meters
+
+---
+*Sources: [Dive Training Magazine — King's Spring](https://dtmag.com/scuba-diving-destinations/kings-spring/), [DiveBuddy — King's Springs](https://www.divebuddy.com/divesite/1334/kings-springs-crystal-river-fl/). Last updated 2026-08-08.*

--- a/divesites/crystal-river/kp-hole-county-park.md
+++ b/divesites/crystal-river/kp-hole-county-park.md
@@ -1,0 +1,31 @@
+---
+name: K.P. Hole County Park
+lat: 29.08678
+lng: -82.43029
+difficulty: Beginner
+maxDepth: 6
+entryType: shore
+siteType: drift
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## K.P. Hole County Park
+
+K.P. Hole County Park is a drift dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+The primary public access point for the Rainbow River downstream of Rainbow Springs State Park, with a boat ramp and a kayak, canoe, and paddleboard launch. Water stays around 72°F with commonly cited visibility of 100+ ft. Sources describe the river as a drift/snorkel experience rather than a fixed dive site: shallow channels, roughly 5–8 ft, connect to deeper holes — up to 20–27 ft depending on the source — that can be scuba-dived, and divers commonly shuttle upstream and drift back down. This is a snorkel and drift-dive river, not a technical scuba destination. Tubing (seasonal, April–September), alcohol, and disposable containers are all regulated here as part of an Outstanding Florida Water / Aquatic Preserve.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Drift dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 6 meters
+
+---
+*Sources: [Visit Florida Springs — KP Hole Park](https://visitfloridasprings.org/places/kp-hole-park/), [ScubaBoard — Rainbow River Drift Dives](https://scubaboard.com/community/threads/rainbow-river-drift-dives.371821/). Last updated 2026-08-08.*

--- a/divesites/crystal-river/overview.md
+++ b/divesites/crystal-river/overview.md
@@ -1,0 +1,42 @@
+---
+addedBy: curated_research
+---
+
+## Crystal River & Rainbow River
+
+Spring-fed snorkeling and diving on Florida's Nature Coast, centered on Crystal River / Kings Bay — the only place in the US where the public may legally enter the water with wild manatees in season — plus the exceptionally clear Rainbow River near Dunnellon.
+
+## Description
+
+Crystal River / Kings Bay (Citrus County) is a spring-fed estuary containing over 70 individual springs discharging roughly 600 million gallons per day from the Floridan Aquifer, holding "Outstanding Florida Water" designation. Spring water stays close to 72°F (22°C) year-round. This is the only place in the US where the public may legally enter the water with wild manatees, in designated areas of the Crystal River National Wildlife Refuge, established in 1983 specifically to protect this wintering population. About 35 miles north, the Rainbow River near Dunnellon is fed by Rainbow Springs, Florida's fourth-largest first-magnitude spring, known for exceptional water clarity and a swimmable/snorkelable spring run — it is best characterized as a snorkeling, tubing, and drift-snorkel/dive river rather than a true scuba destination.
+
+### Diving Opportunities
+
+- **Manatee Encounters**: Wild manatees winter in Kings Bay roughly November 15–March 31, seeking the springs' constant warm water as Gulf temperatures drop. Federal and state regulations require passive observation only — no touching, chasing, cornering, or feeding, and posted sanctuary zones are off-limits to entry.
+- **Spring Snorkeling/Diving**: Named springs around Kings Bay (Three Sisters Springs, King Spring, Idiot's Delight, Jurassic Spring) and the Rainbow Springs headspring offer clear, warm-water snorkeling and, in some cases, scuba diving — access rules and seasonal restrictions vary by specific site.
+- **River Drift-Snorkeling**: The Rainbow River, accessed via K.P. Hole County Park, is commonly drift-snorkeled or drift-dived downstream from a shuttle put-in.
+
+### Accessibility
+
+- **Getting There**: Ocala International Airport or Tampa International Airport are the nearest major airports; both Crystal River and Dunnellon are reachable by car from either.
+- **Access**: Most Kings Bay springs require a kayak, paddle-craft, or boat — there is little direct road/shore access to the springs themselves, aside from a few shoreline parks. Rainbow River sites have direct shore/boat-ramp access via the state park and K.P. Hole County Park.
+
+### Conditions
+
+- **Water Type**: Freshwater, spring-fed.
+- **Season**: Manatee season runs roughly Nov 15–Mar 31; diving/snorkeling is possible year-round, but some Kings Bay sites restrict scuba diving to specific months (e.g., Three Sisters Springs permits scuba only April 1–Nov 14).
+- **Visibility**: Generally excellent in the spring pools and upper river; Rainbow River commonly reports 20–100+ ft depending on rainfall.
+- **Temperature**: Constant ~72°F (22°C) at the springs.
+
+### Conservation
+
+Manatees are a federally protected species; violating sanctuary boundaries or approach rules carries legal penalties. Both Kings Bay and the Rainbow River are designated Outstanding Florida Waters / Aquatic Preserves.
+
+## Additional Information
+
+- **Currency**: US Dollar
+- **Language**: English
+- **Safety**: Follow FWC/FWS manatee viewing guidelines strictly — float passively, do not touch or chase, and respect all posted sanctuary boundaries. Several Kings Bay springs have associated cave/cavern systems requiring specific cave certification for any penetration beyond the open, daylight-zone pool.
+
+---
+*Sources: [FWS Crystal River National Wildlife Refuge](https://www.fws.gov/refuge/crystal-river), [Wikipedia — Three Sisters Springs](https://en.wikipedia.org/wiki/Three_Sisters_Springs_(Florida)), [Wikipedia — Rainbow Springs State Park](https://en.wikipedia.org/wiki/Rainbow_Springs_State_Park), [Florida Springs Institute — SpringsWatch: Kings Bay](https://floridaspringsinstitute.org/kings-bay-springs/). Last updated 2026-08-08.*

--- a/divesites/crystal-river/rainbow-springs-headspring.md
+++ b/divesites/crystal-river/rainbow-springs-headspring.md
@@ -1,0 +1,31 @@
+---
+name: Rainbow Springs Headspring
+lat: 29.1026
+lng: -82.437
+difficulty: Beginner
+maxDepth: 4
+entryType: shore
+siteType: cave
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Rainbow Springs Headspring
+
+Rainbow Springs Headspring is a cave dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+The first-magnitude headspring of the Rainbow River (reported flow of 410–600 million gallons per day, depending on the source), emerging from dozens of vents into a wide, swimmable basin within Rainbow Springs State Park. Water holds a constant ~72°F with commonly reported visibility of 20–40+ ft, reduced after heavy rain per one source. It was historically called 'Blue Spring' until a 1930s tourism rebrand that included submarine boat tours and, in the 1950s, mermaid shows; the state acquired the land in 1990. This is explicitly a swimming and snorkeling site, not a scuba destination — the park's own activity guidance centers on swimming, snorkeling, canoeing, and kayaking, and snorkeling is permitted only within a buoyed swim area. The depth figure here comes from a single aggregator source and wasn't independently cross-confirmed — treat it as approximate.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Cave/cavern
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 4 meters
+
+---
+*Sources: [Wikipedia — Rainbow Springs State Park](https://en.wikipedia.org/wiki/Rainbow_Springs_State_Park), [Florida State Parks — Rainbow Springs](https://www.floridastateparks.org/parks-and-trails/rainbow-springs-state-park/experiences-amenities). Last updated 2026-08-08.*

--- a/divesites/crystal-river/three-sisters-springs.md
+++ b/divesites/crystal-river/three-sisters-springs.md
@@ -1,0 +1,31 @@
+---
+name: Three Sisters Springs
+lat: 28.888725
+lng: -82.589191
+difficulty: Beginner
+maxDepth: 3
+entryType: boat
+siteType: cave
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Three Sisters Springs
+
+Three Sisters Springs is a cave dive site in Crystal River & Rainbow River, North America.
+
+## Overview
+
+A 57-acre unit of Crystal River National Wildlife Refuge on Kings Bay, made up of three linked spring pools nicknamed Little Sister, Big Sister, and Pretty Sister. Water holds a stable ~73°F year-round. This is documented as the only enclosed water body in the US where the public may legally enter the water with wintering manatees, present roughly November 15–March 31 as they seek warmth from cooling Gulf water. There's no direct road or shore water access — visitors reach it by kayak, paddle-craft, or swimming from an outside launch (a land-based boardwalk offers viewing only, not water entry). Scuba diving is permitted only April 1–November 14; snorkeling runs year-round but is subject to sanctuary boundary closures swimmers may not cross. Depth isn't stated precisely by sources — treat the figure here as a rough estimate for shallow wading/snorkeling pools.
+
+## Site Information
+
+- **Location**: Crystal River & Rainbow River, North America
+- **Entry Type**: Boat dive
+- **Site Type**: Cave/cavern
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 3 meters
+
+---
+*Sources: [Wikipedia — Three Sisters Springs (Florida)](https://en.wikipedia.org/wiki/Three_Sisters_Springs_(Florida)), [US Fish & Wildlife Service — Scuba Diving](https://www.fws.gov/refuge/crystal-river/visit-us/activities/scuba-diving). Last updated 2026-08-08.*

--- a/divesites/venice-beach/blind-pass-beach.md
+++ b/divesites/venice-beach/blind-pass-beach.md
@@ -1,0 +1,31 @@
+---
+name: Blind Pass Beach
+lat: 26.958539
+lng: -82.38281
+difficulty: Beginner
+maxDepth: 1.5
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Blind Pass Beach
+
+Blind Pass Beach is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A quieter, less-developed county beach park at the tidal cut, or 'pass,' between Manasota Key and Palm Island. Tidal action through the pass is described as consistently depositing shells, sand dollars, and shark teeth along the shoreline; multiple sources note clearer, emerald-tinted water here than is typical for the area.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 1.5 meters
+
+---
+*Sources: [VISIT FLORIDA — Blind Pass Beach Guide](https://www.visitflorida.com/travel-ideas/articles/beach-guide-blind-pass-manasota-key/), [Visit Sarasota County — Blind Pass Beach](https://www.visitsarasota.com/beaches-parks/blind-pass-beach). Last updated 2026-08-08.*

--- a/divesites/venice-beach/brohard-beach-north-brohard-paw-park.md
+++ b/divesites/venice-beach/brohard-beach-north-brohard-paw-park.md
@@ -1,0 +1,31 @@
+---
+name: Brohard Beach (North Brohard Paw Park)
+lat: 27.0745
+lng: -82.4503
+difficulty: Beginner
+maxDepth: 1
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Brohard Beach (North Brohard Paw Park)
+
+Brohard Beach (North Brohard Paw Park) is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+Venice's only dog-friendly beach, immediately north of the Venice Fishing Pier area. Shark teeth wash up mixed with shells, more easily found after storms or at low tide. One source explicitly notes unpredictable rip currents here, distinct from the calmer conditions at Caspersen Beach — worth keeping in mind for less experienced waders or snorkelers. **Coordinate note**: this location was interpolated from the park's street address rather than independently geocoded — treat it as approximate.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 1 meters
+
+---
+*Sources: [City of Venice, FL — North Brohard Park](https://www.venicegov.com/Home/Components/FacilityDirectory/FacilityDirectory/36/265). Last updated 2026-08-08.*

--- a/divesites/venice-beach/caspersen-beach.md
+++ b/divesites/venice-beach/caspersen-beach.md
@@ -1,0 +1,31 @@
+---
+name: Caspersen Beach
+lat: 27.057233
+lng: -82.4427
+difficulty: Beginner
+maxDepth: 2
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Caspersen Beach
+
+Caspersen Beach is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A largely undeveloped, roughly 2.5-mile county park beach south of downtown Venice, widely cited across independent sources as the single best free shark-tooth beach in the area. The rocky, less-trafficked shoreline and thick black-sand/shell lines concentrate fossils; hunting is best in the surf zone and between the beach and first sandbar, especially at low tide and after storms. Reported finds, well-corroborated across sources, include sand, lemon, mako, bull, and whitetip shark teeth, plus occasional megalodon teeth.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 2 meters
+
+---
+*Sources: [Must Do Visitor Guides — Caspersen Beach](https://www.mustdo.com/articles/hunt-for-sharks-teeth-on-caspersen-beach-in-venice/), [VISIT FLORIDA — Caspersen Beach](https://www.visitflorida.com/travel-ideas/articles/finding-shark-teeth-on-caspersen-beach-in-venice-fla/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/index.json
+++ b/divesites/venice-beach/index.json
@@ -1,0 +1,122 @@
+[
+  {
+    "name": "Caspersen Beach",
+    "filename": "caspersen-beach.md",
+    "lat": 27.057233,
+    "lng": -82.4427,
+    "difficulty": "Beginner",
+    "maxDepth": 2,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Brohard Beach (North Brohard Paw Park)",
+    "filename": "brohard-beach-north-brohard-paw-park.md",
+    "lat": 27.0745,
+    "lng": -82.4503,
+    "difficulty": "Beginner",
+    "maxDepth": 1,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "South Brohard Park",
+    "filename": "south-brohard-park.md",
+    "lat": 27.068,
+    "lng": -82.448,
+    "difficulty": "Intermediate",
+    "maxDepth": 4.5,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Venice Fishing Pier (Sharky's Beach)",
+    "filename": "venice-fishing-pier-sharkys-beach.md",
+    "lat": 27.073216,
+    "lng": -82.449724,
+    "difficulty": "Beginner",
+    "maxDepth": 5,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Service Club Park",
+    "filename": "service-club-park.md",
+    "lat": 27.076,
+    "lng": -82.451,
+    "difficulty": "Beginner",
+    "maxDepth": 4.5,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Venice Beach (Main/North Public Beach)",
+    "filename": "venice-beach-mainnorth-public-beach.md",
+    "lat": 27.09758,
+    "lng": -82.46225,
+    "difficulty": "Beginner",
+    "maxDepth": 5.8,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Manasota Beach",
+    "filename": "manasota-beach.md",
+    "lat": 26.94028,
+    "lng": -82.36389,
+    "difficulty": "Beginner",
+    "maxDepth": 1,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Blind Pass Beach",
+    "filename": "blind-pass-beach.md",
+    "lat": 26.958539,
+    "lng": -82.38281,
+    "difficulty": "Beginner",
+    "maxDepth": 1.5,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "Nokomis Beach",
+    "filename": "nokomis-beach.md",
+    "lat": 27.124,
+    "lng": -82.47,
+    "difficulty": "Beginner",
+    "maxDepth": 1,
+    "entryType": "shore",
+    "siteType": "beach",
+    "ref": "",
+    "osmId": null
+  },
+  {
+    "name": "The Boneyard",
+    "filename": "the-boneyard.md",
+    "lat": 27.085,
+    "lng": -82.468,
+    "difficulty": "Intermediate",
+    "maxDepth": 8,
+    "entryType": "boat",
+    "siteType": "muck",
+    "ref": "",
+    "osmId": null
+  }
+]

--- a/divesites/venice-beach/manasota-beach.md
+++ b/divesites/venice-beach/manasota-beach.md
@@ -1,0 +1,31 @@
+---
+name: Manasota Beach
+lat: 26.94028
+lng: -82.36389
+difficulty: Beginner
+maxDepth: 1
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Manasota Beach
+
+Manasota Beach is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A Sarasota County park beach on Manasota Key, described as 'the gateway to the Shark Tooth Capital of the World.' One distinctive, well-corroborated detail: shark teeth are visibly embedded in the concrete of the beach's boardwalk and walkway itself, in addition to being found in the sand and shallow water while wading knee to waist deep.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 1 meters
+
+---
+*Sources: [FossilGuy.com — Venice Guide](https://www.fossilguy.com/sites/venice/index.htm). Last updated 2026-08-08.*

--- a/divesites/venice-beach/nokomis-beach.md
+++ b/divesites/venice-beach/nokomis-beach.md
@@ -1,0 +1,31 @@
+---
+name: Nokomis Beach
+lat: 27.124
+lng: -82.47
+difficulty: Beginner
+maxDepth: 1
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Nokomis Beach
+
+Nokomis Beach is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A public beach on the southern portion of Casey Key, north of Venice proper. Multiple sources explicitly caveat that teeth here are smaller and less concentrated than at Venice-area beaches like Caspersen, though the less-crowded northern stretch — a short walk from the main access point — is reported to be more productive than the immediate access area. **Coordinate note**: this location is approximate (Nokomis Beach Pavilion area), not independently geocoded.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 1 meters
+
+---
+*Sources: [Local Life Homes — Nokomis Beach Guide](https://www.locallifehomes.com/blog/nokomis-beach-guide/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/overview.md
+++ b/divesites/venice-beach/overview.md
@@ -1,0 +1,38 @@
+---
+addedBy: curated_research
+---
+
+## Venice Beach
+
+The self-proclaimed "Shark Tooth Capital of the World" on Florida's Sarasota County Gulf Coast, where fossilized shark teeth erode out of the offshore Peace River Formation and wash up on beaches or concentrate in an ancient submerged riverbed reachable by boat.
+
+## Description
+
+The Venice-Sarasota County coastline sits atop the Peace River Formation, a phosphate-rich sedimentary layer deposited during the Miocene into the early Pliocene (roughly 3–23 million years ago). During this period Florida's peninsula extended much farther into the Gulf, and the area was a shallow, nutrient-rich coastal/riverine environment used by megalodon and other sharks. The formation lies close to the modern seafloor, and wave action, storms, and tidal erosion continually release fossilized teeth that wash toward shore and concentrate offshore in old riverbed channels.
+
+### Diving Opportunities
+
+- **Shore Fossil Hunting**: Most sites here are shallow, shore-accessible beaches where teeth are found by wading and sifting sand in the surf zone, most productively after storms or at low tide.
+- **Boat Diving**: An offshore submerged riverbed known as "The Boneyard," roughly half a mile to a mile out, is the primary target for divers seeking larger, better-preserved megalodon teeth and other Pleistocene mammal fossils that don't survive the trip to shore intact.
+- **Regulations**: Recreational collection of shark and ray teeth requires no permit anywhere in Florida. Collecting other vertebrate fossils (mammoth, mastodon, horse, etc.) legally requires a $5/year Florida Fossil Permit from the Florida Museum of Natural History, and significant finds must be reported. Collecting is prohibited in state parks and other protected lands regardless of permit status.
+
+### Accessibility
+
+- **Getting There**: Sarasota-Bradenton International Airport (SRQ) or Tampa International Airport (TPA) are the nearest major airports.
+- **Access**: Most sites are public county/city beach parks with parking; the offshore Boneyard site requires a boat.
+
+### Conditions
+
+- **Water Type**: Warm Gulf of Mexico saltwater.
+- **Season**: Shore hunting is most productive in winter after storms/cold fronts; boat diving is more weather-dependent and can be attempted on calm days year-round.
+- **Visibility**: Generally poor to fair by dive standards — commonly reported in the 5–15 ft range, occasionally as low as 1–2 ft in choppy conditions, up to 20–25 ft on excellent days.
+- **Temperature**: Roughly 64°F (18°C) in January to 86–87°F (30°C) in August.
+
+## Additional Information
+
+- **Currency**: US Dollar
+- **Language**: English
+- **Safety**: Boat traffic is a specifically noted hazard at several shore sites — use a dive flag/buoy. Some sites have reported rip currents. Fossil hunters routinely dig/sift in shallow water; use caution around any structure (artificial reef, pier pilings).
+
+---
+*Sources: [FloridaTrend — Dental work: A bed of bones off Venice, Florida](https://www.floridatrend.com/article/20004/dental-work-a-bed-of-bones-off-venice-florida/), [FL DEP — Florida Fossil Collecting](https://floridadep.gov/fgs/geologic-topics/content/florida-fossil-collecting), [Florida Museum — Fossil Permit](https://floridamuseum.ufl.edu/vertpaleo/amateur-collector/fossil-permit), [VISIT FLORIDA — Caspersen Beach](https://www.visitflorida.com/travel-ideas/articles/finding-shark-teeth-on-caspersen-beach-in-venice-fla/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/service-club-park.md
+++ b/divesites/venice-beach/service-club-park.md
@@ -1,0 +1,31 @@
+---
+name: Service Club Park
+lat: 27.076
+lng: -82.451
+difficulty: Beginner
+maxDepth: 4.5
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Service Club Park
+
+Service Club Park is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A community-built park, developed by local service clubs, with a boardwalk down to the beach and paved parking. Multiple independent sources specifically cite this site for megalodon tooth discoveries on the sandy Gulf floor just offshore, roughly 100 yards out on a heading of 250 degrees from the boardwalk steps, with a 'culvert' artificial reef about 200 yards farther out. Limited, small parking is noted as a drawback. **Coordinate note**: this location was interpolated from the park's street address rather than independently geocoded — treat it as approximate.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 4.5 meters
+
+---
+*Sources: [City of Venice, FL — Service Club Park](https://www.venicegov.com/Home/Components/FacilityDirectory/FacilityDirectory/59/265), [ScubaBoard — Insider Info and Directions to Venice Beaches](https://scubaboard.com/community/threads/insider-info-and-directions-to-venice-beaches.262449/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/south-brohard-park.md
+++ b/divesites/venice-beach/south-brohard-park.md
@@ -1,0 +1,31 @@
+---
+name: South Brohard Park
+lat: 27.068
+lng: -82.448
+difficulty: Intermediate
+maxDepth: 4.5
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## South Brohard Park
+
+South Brohard Park is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+A day-use park, separate from the dog-friendly North Brohard/Paw Park, offering shore access to a placed limestone-block artificial reef and a coquina reef, plus a black-sand fossil zone farther offshore. A detailed first-hand trip report explicitly called this site not recommended for beginners, given the long swims required with heavy collection bags. That same report lists mammal fossils, shark teeth, mammoth bone and tusk fragments, horse and llama teeth, and alligator and turtle fossils among the finds here — a single trip-report source for that specific species list, not independently cross-confirmed. **Coordinate note**: source addresses for this park conflicted, so the location here is approximate, not independently geocoded.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Intermediate
+- **Maximum Depth**: 4.5 meters
+
+---
+*Sources: [ScubaBoard — Insider Info and Directions to Venice Beaches](https://scubaboard.com/community/threads/insider-info-and-directions-to-venice-beaches.262449/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/the-boneyard.md
+++ b/divesites/venice-beach/the-boneyard.md
@@ -1,0 +1,31 @@
+---
+name: The Boneyard
+lat: 27.085
+lng: -82.468
+difficulty: Intermediate
+maxDepth: 8
+entryType: boat
+siteType: muck
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## The Boneyard
+
+The Boneyard is a muck dive site in Venice Beach, North America.
+
+## Overview
+
+An ancient, submerged riverbed roughly half a mile to a mile offshore from the Venice/Alhambra area, running roughly parallel to the coast. According to Richard C. Hulbert Jr., vertebrate paleontology collections manager at the Florida Museum of Natural History, the sediments here were deposited 3–10 million years ago, when Florida's coastline extended much farther into the Gulf. The bone bed contains megalodon teeth reported up to 7 inches, plus remains attributed to saber-toothed cats, Columbian mammoths, 'bear dogs,' American lions, gomphotheres, camels, and horses — this is the site local dive charters target for larger, better-preserved teeth that don't typically survive the trip to the beach intact. Depth is reported at 25–35 ft across sources, most consistently around 25–30 ft. It's a soft-sediment, anchor-dive search site with little to no current, per charter descriptions — not a true current-driven drift site. **Coordinate note**: exact coordinates aren't publicly documented; charter operators reportedly keep them private, so the location here is based on one hobbyist-shared GPS post on a dive forum and should be treated as unverified and approximate.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Boat dive
+- **Site Type**: Muck dive
+- **Difficulty Level**: Intermediate
+- **Maximum Depth**: 8 meters
+
+---
+*Sources: [FloridaTrend — Dental Work: A Bed of Bones Off Venice, Florida](https://www.floridatrend.com/article/20004/dental-work-a-bed-of-bones-off-venice-florida/), [ScubaBoard — Where's the Bone Yard?](https://scubaboard.com/community/threads/wheres-the-bone-yard.292005/). Last updated 2026-08-08.*

--- a/divesites/venice-beach/venice-beach-mainnorth-public-beach.md
+++ b/divesites/venice-beach/venice-beach-mainnorth-public-beach.md
@@ -1,0 +1,31 @@
+---
+name: Venice Beach (Main/North Public Beach)
+lat: 27.09758
+lng: -82.46225
+difficulty: Beginner
+maxDepth: 5.8
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Venice Beach (Main/North Public Beach)
+
+Venice Beach (Main/North Public Beach) is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+Venice's main public beach near the historic downtown and lifeguard-tower area, north of the pier. **Depth conflict**: an official PADI dive-site listing gives a maximum depth of only 6 ft, while independent diver reviews describe a productive zone about 100 yards offshore from the lifeguard tower at 16–21 ft, with a stated site maximum of 19 ft — both figures are reported here rather than resolved to one number. The beach is widely reported as a productive shore snorkel/dive fossil site, with rocky reef structures and sand dollars offshore; one reviewer reported finding upwards of 60 teeth in a one-hour dive, some over 4 inches — a single-source claim, not independently corroborated. Visibility is reported as poor and dependent on chop, roughly 5–15 ft typically and occasionally down to 1–2 ft. Boat traffic is a specifically noted hazard here — divers are advised to use a dive flag or buoy.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 5.8 meters
+
+---
+*Sources: [PADI Dive Site — Venice Beach (Shark Tooth)](https://www.padi.com/dive-site/united-states-of-america-usa/venice-beach-shark-tooth/), [Zentacle — Venice Beach](https://www.zentacle.com/Beach/1485/venice-beach). Last updated 2026-08-08.*

--- a/divesites/venice-beach/venice-fishing-pier-sharkys-beach.md
+++ b/divesites/venice-beach/venice-fishing-pier-sharkys-beach.md
@@ -1,0 +1,31 @@
+---
+name: Venice Fishing Pier (Sharky's Beach)
+lat: 27.073216
+lng: -82.449724
+difficulty: Beginner
+maxDepth: 5
+entryType: shore
+siteType: beach
+ref: null
+osmId: null
+addedBy: osm_import
+---
+
+## Venice Fishing Pier (Sharky's Beach)
+
+Venice Fishing Pier (Sharky's Beach) is a beach dive site in Venice Beach, North America.
+
+## Overview
+
+The area around the Venice Fishing Pier and the adjacent Sharky's restaurant and pavilion, informally split by divers into north and south sections. Sources report a broken shell and black sand bottom at depth, roughly 150 yards offshore past a shallow sandbar. **Access note**: divers must stay more than 100 yards from the pier itself when scuba diving, according to one local diver's account of Sheriff's Department enforcement — worth confirming current local rules before diving here.
+
+## Site Information
+
+- **Location**: Venice Beach, North America
+- **Entry Type**: Shore entry
+- **Site Type**: Beach dive
+- **Difficulty Level**: Beginner
+- **Maximum Depth**: 5 meters
+
+---
+*Sources: [ScubaBoard — Insider Info and Directions to Venice Beaches](https://scubaboard.com/community/threads/insider-info-and-directions-to-venice-beaches.262449/), [ScubaBoard — ReefGuy's Venice Beach Tooth Finding Guide](https://scubaboard.com/community/threads/reefguys-venice-beach-tooth-finding-guide.126440/). Last updated 2026-08-08.*


### PR DESCRIPTION
## Summary

Two new destinations, 17 sites total:

- **Crystal River & Rainbow River** (7 sites) — Nature Coast spring diving/snorkeling centered on Kings Bay, the only place in the US where the public may legally enter the water with wild manatees in season, plus the Rainbow River near Dunnellon.
- **Venice Beach** (10 sites) — Sarasota County Gulf Coast shark-tooth fossil hunting, including an offshore submerged riverbed ("The Boneyard").

## Sourcing approach

Applying the same standard from #145's review: every site cites real, named, linked sources (dive operators, FWS/FWC, state parks, ScubaBoard, FloridaTrend, Florida Museum of Natural History) — no single unnamed source anywhere. Conflicts and gaps are flagged inline rather than resolved by guessing:

- **Coordinate flags** on 5 sites where location was interpolated from a street address or a single hobbyist-shared GPS post rather than independently geocoded: Brohard Beach, South Brohard Park, Service Club Park, Nokomis Beach, The Boneyard.
- **Depth conflicts stated as ranges**, both figures and sources named rather than picked: King Spring (15–65ft depending on source — possibly conflated with a separate nearby spring, Tarpon Hole, whose identity relative to King Spring wasn't resolved); Venice Beach main (6ft per an official PADI listing vs. 19ft per independent diver reviews).
- **Candidates investigated and excluded** for lacking any independent verification or location data: Tarpon Hole, Catfish Spring, House Spring, Magnolia Spring, Shark Sink, Buzzard Roost, Blue Water Spring, Alhambra Road Site.

## Destination structure

Crystal River/Rainbow River didn't fit into the existing `florida-springs` destination — they're ~35 miles south of its bounds and a fundamentally different character (manatee/snorkel tourism vs. cave diving), so stretching that destination's bounding box across the gap would have been misleading. Made a new combined destination instead.

## Difficulty ratings

Followed the depth-based rule from #145's review (≥30m → Advanced, 18–30m → at least Intermediate). All 17 sites here are shallow enough that the rule didn't force any escalation, but Intermediate/Advanced was kept where a source explicitly justified it for reasons other than depth (South Brohard Park's long swim with gear, The Boneyard's boat-entry navigation demands).

## Test plan

- [x] All JSON files validated to parse correctly
- [x] `scripts/generate_sites.py` and `scripts/sync_sites.py` run successfully for both destinations, `index.json` counts match source data (crystal-river: 7, venice-beach: 10)
- [x] No leftover auto-generated stub text in any new markdown file
- [x] No difficulty/depth safety-rule violations
- [x] No sites outside either destination's bounding box
- [x] No duplicate site names within or across destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)